### PR TITLE
Add timeout to e2e-tests CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint-and-build
     # Only run when test secrets are configured
     if: ${{ vars.E2E_ENABLED == 'true' }}


### PR DESCRIPTION
Prevent hung CI runners from persisting beyond their expected runtime. Set timeout-minutes: 15 on the e2e-tests job to catch hanging tests early instead of letting them waste resources for hours.

This was added after a CI run hung for 23+ hours, likely due to auth polling loops not resolving in the runner environment.

🤖 Generated with Claude Code