### PR TITLE
Add household data export (JSON)

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -14,6 +14,7 @@ import { notesRouter } from "./routers/notes.js";
 import { reportingRouter } from "./routers/reporting.js";
 import { analyticsRouter } from "./routers/analytics.js";
 import { gamificationRouter } from "./routers/gamification.js";
+import { exportRouter } from "./routers/export.js";
 
 export const appRouter = router({
   household: householdRouter,
@@ -31,6 +32,7 @@ export const appRouter = router({
   reporting: reportingRouter,
   analytics: analyticsRouter,
   gamification: gamificationRouter,
+  export: exportRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/api/src/routers/export.ts
+++ b/apps/api/src/routers/export.ts
@@ -1,0 +1,129 @@
+import { router, householdProcedure } from "../trpc.js";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import {
+  db,
+  households,
+  members,
+  pets,
+  activities,
+  feedingSchedules,
+  feedingLogs,
+  healthRecords,
+  medications,
+  medicationLogs,
+  expenses,
+  petNotes,
+  memberGameStats,
+  householdGameStats,
+  petGameStats,
+} from "@petforce/db";
+
+export const exportRouter = router({
+  /**
+   * Export all household data as a structured JSON object.
+   * Restricted to owners and admins.
+   */
+  household: householdProcedure.query(async ({ ctx }) => {
+    const { membership, householdId } = ctx;
+
+    if (membership.role !== "owner" && membership.role !== "admin") {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Only owners and admins can export household data",
+      });
+    }
+
+    // Fetch all data in parallel
+    const [
+      householdRows,
+      memberRows,
+      petRows,
+      activityRows,
+      feedingScheduleRows,
+      feedingLogRows,
+      healthRecordRows,
+      medicationRows,
+      medicationLogRows,
+      expenseRows,
+      noteRows,
+      memberGameRows,
+      householdGameRows,
+      petGameRows,
+    ] = await Promise.all([
+      db.select().from(households).where(eq(households.id, householdId)),
+      db.select().from(members).where(eq(members.householdId, householdId)),
+      db.select().from(pets).where(eq(pets.householdId, householdId)),
+      db.select().from(activities).where(eq(activities.householdId, householdId)),
+      db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, householdId)),
+      db.select().from(feedingLogs).where(eq(feedingLogs.householdId, householdId)),
+      db.select().from(healthRecords).where(eq(healthRecords.householdId, householdId)),
+      db.select().from(medications).where(eq(medications.householdId, householdId)),
+      db.select().from(medicationLogs).where(eq(medicationLogs.householdId, householdId)),
+      db.select().from(expenses).where(eq(expenses.householdId, householdId)),
+      db.select().from(petNotes).where(eq(petNotes.householdId, householdId)),
+      db.select().from(memberGameStats).where(eq(memberGameStats.householdId, householdId)),
+      db.select().from(householdGameStats).where(eq(householdGameStats.householdId, householdId)),
+      db.select().from(petGameStats).where(eq(petGameStats.householdId, householdId)),
+    ]);
+
+    const household = householdRows[0];
+    if (!household) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Household not found" });
+    }
+
+    // Build member lookup for readable names in logs
+    const memberLookup = Object.fromEntries(
+      memberRows.map((m) => [m.id, m.displayName])
+    );
+
+    // Group pet-related data by petId
+    const petData = petRows.map((pet) => ({
+      ...pet,
+      feedingSchedules: feedingScheduleRows
+        .filter((fs) => fs.petId === pet.id)
+        .map((fs) => ({
+          ...fs,
+          logs: feedingLogRows.filter((fl) => fl.feedingScheduleId === fs.id),
+        })),
+      healthRecords: healthRecordRows.filter((hr) => hr.petId === pet.id),
+      medications: medicationRows
+        .filter((med) => med.petId === pet.id)
+        .map((med) => ({
+          ...med,
+          logs: medicationLogRows.filter((ml) => ml.medicationId === med.id),
+        })),
+      activities: activityRows.filter((a) => a.petId === pet.id),
+      expenses: expenseRows.filter((e) => e.petId === pet.id),
+      notes: noteRows.filter((n) => n.petId === pet.id),
+      gamification: petGameRows.find((g) => g.petId === pet.id) ?? null,
+    }));
+
+    // Household-level notes (no pet attached)
+    const householdNotes = noteRows.filter((n) => !n.petId);
+
+    return {
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+      household: {
+        name: household.name,
+        theme: household.theme,
+        createdAt: household.createdAt,
+      },
+      members: memberRows.map((m) => ({
+        displayName: m.displayName,
+        role: m.role,
+        joinedAt: m.joinedAt,
+      })),
+      pets: petData,
+      householdNotes,
+      gamification: {
+        household: householdGameRows[0] ?? null,
+        members: memberGameRows.map((mg) => ({
+          ...mg,
+          memberName: memberLookup[mg.memberId] ?? "Unknown",
+        })),
+      },
+    };
+  }),
+});

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -526,6 +526,9 @@ function HouseholdSettingsTab({
         </div>
       </div>
 
+      {/* Data Export */}
+      <DataExportCard householdId={householdId} householdName={household.name} isAdmin={isAdmin} />
+
       {/* Danger Zone */}
       {isAdmin && (
         <div style={{ ...glassCard, borderColor: "rgba(239, 68, 68, 0.3)" }}>
@@ -548,6 +551,98 @@ function HouseholdSettingsTab({
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+// ── Data Export Card ──
+
+function DataExportCard({
+  householdId,
+  householdName,
+  isAdmin,
+}: {
+  householdId: string;
+  householdName: string;
+  isAdmin: boolean;
+}) {
+  const [exporting, setExporting] = useState(false);
+  const [exported, setExported] = useState(false);
+  const trackEvent = useTrackEvent();
+
+  const exportQuery = trpc.export.household.useQuery(
+    { householdId },
+    { enabled: false } // only fetch on demand
+  );
+
+  const handleExport = async () => {
+    setExporting(true);
+    setExported(false);
+    try {
+      const result = await exportQuery.refetch();
+      if (result.data) {
+        const json = JSON.stringify(result.data, null, 2);
+        const blob = new Blob([json], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        const slug = householdName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+        a.href = url;
+        a.download = `petforce-${slug}-export-${new Date().toISOString().slice(0, 10)}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        setExported(true);
+        trackEvent("data.exported", { format: "json" });
+        setTimeout(() => setExported(false), 3000);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div style={glassCard}>
+        <h2 style={sectionTitle}>Data Export</h2>
+        <p style={{ fontSize: "0.8rem", color: "var(--pf-text-muted)", margin: 0 }}>
+          Only owners and admins can export household data.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={glassCard}>
+      <h2 style={sectionTitle}>Data Export</h2>
+      <p style={{ fontSize: "0.8rem", color: "var(--pf-text-muted)", margin: "0 0 0.75rem" }}>
+        Download all your household data including pets, health records, medications, feeding schedules, expenses, and activities as a JSON file.
+      </p>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+        <button
+          onClick={handleExport}
+          disabled={exporting}
+          style={{
+            ...actionButton,
+            background: exporting
+              ? "linear-gradient(135deg, #6B7280, #9CA3AF)"
+              : "linear-gradient(135deg, #6366F1, #818CF8)",
+            cursor: exporting ? "wait" : "pointer",
+          }}
+        >
+          {exporting ? "Exporting..." : "Export as JSON"}
+        </button>
+        {exported && (
+          <span style={{ fontSize: "0.8rem", color: "var(--pf-success)", fontWeight: 600 }}>
+            Download started!
+          </span>
+        )}
+        {exportQuery.isError && (
+          <span style={{ fontSize: "0.8rem", color: "var(--pf-error)" }}>
+            Export failed. Please try again.
+          </span>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New `export` tRPC router that aggregates all household data (pets, health records, medications, feeding schedules, expenses, activities, notes, gamification) into a structured JSON blob
- Owner/admin-only access control
- "Data Export" card added to Settings page with one-click JSON download
- File named `petforce-{household}-export-{date}.json`

## Test plan
- [ ] Navigate to Settings > Settings tab as an owner/admin
- [ ] Click "Export as JSON" and verify a JSON file downloads
- [ ] Verify the JSON contains all household data (pets, health records, etc.)
- [ ] Verify non-admin members see "Only owners and admins can export" message
- [ ] Verify the export is tracked as a `data.exported` analytics event

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)