### PR TITLE
Fix flaky household ID in E2E tests

### DIFF
--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import "./helpers/load-env";
 
 const authFile = path.join(__dirname, ".auth/session.json");
+const API_BASE = "http://localhost:3001";
 
 setup("sign in with Clerk test mode", async ({ page }) => {
   await clerkTestSignIn(page);
@@ -16,10 +17,60 @@ setup("sign in with Clerk test mode", async ({ page }) => {
     await page
       .locator("text=/Pets|No pets yet|Members|Redirecting|Create your household/")
       .first()
-      .waitFor({ state: "visible", timeout: 10_000 });
+      .waitFor({ state: "visible", timeout: 15_000 });
     await page.waitForTimeout(2000);
   } catch {
     // Dashboard may not fully load if user needs onboarding — that's OK
+  }
+
+  // Poll localStorage for petforce_household_id (React useEffect may be slow on CI)
+  let householdId = await page.evaluate(() =>
+    localStorage.getItem("petforce_household_id")
+  );
+
+  if (!householdId) {
+    console.log("auth.setup: household ID not in localStorage yet, polling...");
+    for (let i = 0; i < 10; i++) {
+      await page.waitForTimeout(1000);
+      householdId = await page.evaluate(() =>
+        localStorage.getItem("petforce_household_id")
+      );
+      if (householdId) break;
+    }
+  }
+
+  // Fallback: extract Clerk token and query the API directly
+  if (!householdId) {
+    console.log("auth.setup: polling failed, querying API directly");
+    try {
+      const token = await page.evaluate(async () => {
+        const clerk = (window as unknown as { Clerk?: { session?: { getToken: () => Promise<string> } } }).Clerk;
+        if (clerk?.session) return await clerk.session.getToken();
+        return null;
+      });
+      if (token) {
+        const res = await fetch(`${API_BASE}/trpc/household.list`, {
+          headers: { authorization: `Bearer ${token}` },
+        });
+        const body = await res.json();
+        const households =
+          body.result?.data?.json ?? body.result?.data ?? body.result;
+        if (Array.isArray(households) && households.length > 0) {
+          householdId = households[0].id;
+          await page.evaluate(
+            (hid: string) => localStorage.setItem("petforce_household_id", hid),
+            householdId
+          );
+          console.log("auth.setup: set household ID via API:", householdId);
+        } else {
+          console.log("auth.setup: user has no households (new user?)");
+        }
+      }
+    } catch (err: unknown) {
+      console.log("auth.setup: API fallback failed:", (err as Error).message);
+    }
+  } else {
+    console.log("auth.setup: household ID found:", householdId);
   }
 
   // Ensure auth directory exists

--- a/tests/e2e/helpers/api-client.ts
+++ b/tests/e2e/helpers/api-client.ts
@@ -189,11 +189,51 @@ export async function trpcQuery(
 
 /**
  * Reads the active household ID from the browser's localStorage.
+ * Polls for up to 15s if not immediately available (React useEffect timing).
+ * Falls back to querying the API directly via the page's Clerk token.
  */
 export async function getHouseholdId(page: Page): Promise<string> {
-  const id = await page.evaluate(() => localStorage.getItem("petforce_household_id"));
-  if (!id) throw new Error("No petforce_household_id found in localStorage");
-  return id;
+  // Try immediately
+  let id = await page.evaluate(() => localStorage.getItem("petforce_household_id"));
+  if (id) return id;
+
+  // Poll for React hydration + useEffect to set localStorage
+  for (let i = 0; i < 10; i++) {
+    await page.waitForTimeout(1500);
+    id = await page.evaluate(() => localStorage.getItem("petforce_household_id"));
+    if (id) return id;
+  }
+
+  // Fallback: extract Clerk token and query API directly
+  console.log("getHouseholdId: localStorage empty after 15s, trying direct API query");
+  try {
+    const token = await page.evaluate(async () => {
+      const clerk = (window as unknown as { Clerk?: { session?: { getToken: () => Promise<string> } } }).Clerk;
+      if (clerk?.session) return await clerk.session.getToken();
+      return null;
+    });
+    if (token) {
+      const res = await fetch(`${API_BASE}/trpc/household.list`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      const body = await res.json();
+      const households =
+        body.result?.data?.json ?? body.result?.data ?? body.result;
+      if (Array.isArray(households) && households.length > 0) {
+        id = households[0].id;
+        await page.evaluate(
+          (hid: string) => localStorage.setItem("petforce_household_id", hid),
+          id
+        );
+        console.log("getHouseholdId: set via direct API query:", id);
+        return id;
+      }
+    }
+  } catch (err: unknown) {
+    console.log("getHouseholdId: API fallback failed:", (err as Error).message);
+  }
+
+  throw new Error("No petforce_household_id found in localStorage after 15s + API fallback");
 }
 
 /**


### PR DESCRIPTION
## Problem

E2E tests were failing dozens of times in a row with: `No petforce_household_id found in localStorage after 25s`. The root cause was a race condition in the test session setup — the auth setup wasn't guaranteeing the household ID was persisted to localStorage before saving the session state.

## Root Cause

When `auth.setup.ts` signed in, it waited for dashboard content (10s timeout) and then immediately saved the storageState. On slow CI, the React `useEffect` in the dashboard that calls `switchHousehold()` (which sets localStorage) hadn't fired yet. The session was saved without `petforce_household_id`, and every test reusing that session failed.

## Solution

**Two-pronged fix:**

1. **`auth.setup.ts`** now polices localStorage for the household ID (10 attempts × 1s) after dashboard loads, and falls back to querying the `household.list` API directly if needed. Only then does it save the session state.

2. **`getHouseholdId()`** in `api-client.ts` now polls localStorage for 15s instead of instant-failing, with the same API fallback for defense in depth.

## Test Plan

- All E2E tests should now pass consistently, including `household-creation-limit.test.ts`, `invite-admin.test.ts`, `invite-join-page.test.ts`, and others that were failing.
- If tests still timeout on household ID lookup, the improved logging will show exactly where it stalls (localStorage polling vs. API fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)