### PR TITLE
Fix Railway deployment with Dockerfile and PORT env var

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,8 +12,8 @@ COPY packages/core/package.json packages/core/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/config/package.json packages/config/package.json
 
-# Install all deps (frozen lockfile for reproducibility)
-RUN pnpm install --frozen-lockfile
+# Install all deps (frozen lockfile for reproducibility, skip postinstall which needs host files)
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # ── Stage 2: Build ──
 FROM node:20-slim AS builder
@@ -48,7 +48,7 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY packages/core/package.json packages/core/package.json
 COPY packages/db/package.json packages/db/package.json
-RUN pnpm install --frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # Copy built output
 COPY --from=builder /app/apps/api/dist ./apps/api/dist

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -67,7 +67,7 @@ app.use("/trpc/*", async (c) => {
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-const port = Number(process.env.API_PORT) || 3001;
+const port = Number(process.env.PORT) || Number(process.env.API_PORT) || 3001;
 
 console.info(`🐾 PetForce API running on http://localhost:${port}`);
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+dockerfilePath = "apps/api/Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Enable production API deployments to Railway by fixing Docker build failures and environment variable handling.

## Changes
- **railway.toml**: Tell Railway to use the Dockerfile explicitly instead of Railpack auto-detection
- **Dockerfile**: Skip postinstall scripts that require host files (use `--ignore-scripts`)  
- **API server**: Respect Railway's `PORT` env var for proper port binding

The API now deploys successfully to Railway and responds on the health endpoint. This enables the GitHub Actions deployment pipeline (already configured in deploy.yml and preview.yml) to work correctly.

## Test plan
- ✅ API deployed to Railway and responds to health checks
- Ready for production: push to main triggers automatic Railway + Vercel deployment
- PR previews work via Railway ephemeral environments