### PR TITLE
Fix performance, env validation, and rate limiting (#28, #29, #30)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ SUPABASE_SERVICE_ROLE_KEY=sb_secret_xxx
 API_PORT=3001
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_WEB_URL=http://localhost:3000
+
+# Rate Limiting (optional — falls back to in-memory if not set)
+UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your_token

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "@petforce/db": "workspace:*",
     "@supabase/supabase-js": "^2.95.3",
     "@trpc/server": "^10.45.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.36.4",
     "drizzle-orm": "^0.33.0",
     "hono": "^4.5.0",
     "superjson": "^2.2.1",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,11 @@
+import { env } from "./lib/env.js";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serve } from "@hono/node-server";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter } from "./router.js";
 import { verifyClerkToken } from "./lib/clerk-auth.js";
+import { rateLimitMiddleware } from "./lib/rate-limit.js";
 import uploadApp from "./routes/upload.js";
 import type { Context } from "./trpc.js";
 
@@ -12,43 +14,14 @@ const app = new Hono();
 app.use(
   "/*",
   cors({
-    origin: process.env.NEXT_PUBLIC_WEB_URL || "http://localhost:3000",
+    origin: env.NEXT_PUBLIC_WEB_URL ?? "http://localhost:3000",
     credentials: true,
   })
 );
 
-// --- In-memory rate limiter ---
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-const RATE_LIMIT_MAX = 100;
-
-// Clean up stale entries every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, value] of rateLimitMap) {
-    if (now > value.resetAt) rateLimitMap.delete(key);
-  }
-}, 5 * 60 * 1000).unref();
-
-app.use("/trpc/*", async (c, next) => {
-  const ip =
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-    c.req.header("x-real-ip") ||
-    "unknown";
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-  } else {
-    entry.count++;
-    if (entry.count > RATE_LIMIT_MAX) {
-      return c.json({ error: "Too many requests" }, 429);
-    }
-  }
-
-  await next();
-});
+// Rate limiting
+app.use("/trpc/*", rateLimitMiddleware);
+app.use("/upload/*", rateLimitMiddleware);
 
 // --- File upload routes (before tRPC) ---
 app.route("/upload", uploadApp);
@@ -67,7 +40,7 @@ app.use("/trpc/*", async (c) => {
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-const port = Number(process.env.PORT) || Number(process.env.API_PORT) || 3001;
+const port = env.PORT ?? env.API_PORT ?? 3001;
 
 console.info(`🐾 PetForce API running on http://localhost:${port}`);
 

--- a/apps/api/src/lib/clerk-auth.ts
+++ b/apps/api/src/lib/clerk-auth.ts
@@ -1,4 +1,5 @@
 import { verifyToken } from "@clerk/backend";
+import { env } from "./env.js";
 
 /**
  * Verify a Clerk JWT from an Authorization header value.
@@ -11,11 +12,11 @@ export async function verifyClerkToken(
 
   const token = authHeader.slice(7);
   try {
-    const jwtKey = process.env.CLERK_JWT_KEY?.replace(/\\n/g, "\n");
+    const jwtKey = env.CLERK_JWT_KEY?.replace(/\\n/g, "\n");
     const payload = await verifyToken(token, {
       ...(jwtKey
         ? { jwtKey }
-        : { secretKey: process.env.CLERK_SECRET_KEY! }),
+        : { secretKey: env.CLERK_SECRET_KEY! }),
     });
     return payload.sub;
   } catch {

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  // Database
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  DATABASE_POOL_SIZE: z.coerce.number().int().positive().default(25),
+
+  // Clerk Auth (at least one required)
+  CLERK_SECRET_KEY: z.string().min(1).optional(),
+  CLERK_JWT_KEY: z.string().min(1).optional(),
+
+  // Supabase Storage
+  SUPABASE_URL: z.string().url("SUPABASE_URL must be a valid URL"),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, "SUPABASE_SERVICE_ROLE_KEY is required"),
+
+  // Server
+  PORT: z.coerce.number().int().positive().optional(),
+  API_PORT: z.coerce.number().int().positive().optional(),
+
+  // CORS
+  NEXT_PUBLIC_WEB_URL: z.string().url().optional(),
+
+  // Rate Limiting (optional — falls back to in-memory if not set)
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
+}).refine(
+  (data) => data.CLERK_SECRET_KEY || data.CLERK_JWT_KEY,
+  { message: "Either CLERK_SECRET_KEY or CLERK_JWT_KEY must be set" }
+);
+
+export type Env = z.infer<typeof envSchema>;
+
+function validateEnv(): Env {
+  const result = envSchema.safeParse(process.env);
+  if (!result.success) {
+    console.error("❌ Invalid environment variables:");
+    for (const issue of result.error.issues) {
+      console.error(`  - ${issue.path.join(".")}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+  return result.data;
+}
+
+export const env = validateEnv();

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,0 +1,120 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import type { Context as HonoContext } from "hono";
+
+function getClientIp(c: HonoContext): string {
+  return (
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+    c.req.header("x-real-ip") ||
+    "unknown"
+  );
+}
+
+// Determine if path is an auth, upload, or standard route for granular limits
+function getRouteCategory(path: string): "auth" | "upload" | "standard" {
+  if (path.includes("upload")) return "upload";
+  // Auth-related tRPC procedures
+  if (path.includes("household.join") || path.includes("household.create")) return "auth";
+  return "standard";
+}
+
+interface RateLimitResult {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+type RateLimiterFn = (identifier: string, category: "auth" | "upload" | "standard") => Promise<RateLimitResult>;
+
+function createRedisLimiter(): RateLimiterFn {
+  const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  });
+
+  const limiters = {
+    auth: new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(20, "15 m"),
+      prefix: "ratelimit:auth",
+    }),
+    upload: new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(30, "15 m"),
+      prefix: "ratelimit:upload",
+    }),
+    standard: new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(100, "15 m"),
+      prefix: "ratelimit:standard",
+    }),
+  };
+
+  return async (identifier, category) => {
+    const result = await limiters[category].limit(identifier);
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    };
+  };
+}
+
+function createInMemoryLimiter(): RateLimiterFn {
+  const limits = { auth: 20, upload: 30, standard: 100 };
+  const windowMs = 15 * 60 * 1000;
+  const store = new Map<string, { count: number; resetAt: number }>();
+
+  // Clean up stale entries every 5 minutes
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, value] of store) {
+      if (now > value.resetAt) store.delete(key);
+    }
+  }, 5 * 60 * 1000).unref();
+
+  return async (identifier, category) => {
+    const key = `${category}:${identifier}`;
+    const now = Date.now();
+    const max = limits[category];
+    const entry = store.get(key);
+
+    if (!entry || now > entry.resetAt) {
+      store.set(key, { count: 1, resetAt: now + windowMs });
+      return { success: true, limit: max, remaining: max - 1, reset: now + windowMs };
+    }
+
+    entry.count++;
+    const remaining = Math.max(0, max - entry.count);
+    return {
+      success: entry.count <= max,
+      limit: max,
+      remaining,
+      reset: entry.resetAt,
+    };
+  };
+}
+
+const rateLimiter: RateLimiterFn =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? createRedisLimiter()
+    : createInMemoryLimiter();
+
+export async function rateLimitMiddleware(c: HonoContext, next: () => Promise<void>) {
+  const ip = getClientIp(c);
+  const category = getRouteCategory(c.req.path);
+  const result = await rateLimiter(ip, category);
+
+  // Set rate limit headers
+  c.header("X-RateLimit-Limit", String(result.limit));
+  c.header("X-RateLimit-Remaining", String(result.remaining));
+  c.header("X-RateLimit-Reset", String(result.reset));
+
+  if (!result.success) {
+    return c.json({ error: "Too many requests" }, 429);
+  }
+
+  await next();
+}

--- a/apps/api/src/lib/unified-completions.ts
+++ b/apps/api/src/lib/unified-completions.ts
@@ -19,33 +19,60 @@ export interface RawCompletion {
   skipped: boolean;
 }
 
+export interface CompletionCaches {
+  schedules?: { id: string; label: string; householdId: string }[];
+  medications?: { id: string; name: string; petId: string; householdId: string }[];
+}
+
 export async function fetchUnifiedCompletions(
   householdId: string,
   from: string,
-  to: string
+  to: string,
+  caches?: CompletionCaches
 ): Promise<RawCompletion[]> {
   const fromDate = new Date(`${from}T00:00:00Z`);
   const toDate = new Date(`${to}T23:59:59.999Z`);
 
   const results: RawCompletion[] = [];
 
-  // --- Feeding logs ---
-  const fLogs = await db
-    .select()
-    .from(feedingLogs)
-    .where(
-      and(
-        eq(feedingLogs.householdId, householdId),
-        gte(feedingLogs.completedAt, fromDate),
-        lte(feedingLogs.completedAt, toDate)
-      )
-    );
-
-  if (fLogs.length > 0) {
-    const schedules = await db
+  // Fetch all three log types in parallel
+  const [fLogs, mLogs, completedActivities] = await Promise.all([
+    db
       .select()
-      .from(feedingSchedules)
-      .where(eq(feedingSchedules.householdId, householdId));
+      .from(feedingLogs)
+      .where(
+        and(
+          eq(feedingLogs.householdId, householdId),
+          gte(feedingLogs.completedAt, fromDate),
+          lte(feedingLogs.completedAt, toDate)
+        )
+      ),
+    db
+      .select()
+      .from(medicationLogs)
+      .where(
+        and(
+          eq(medicationLogs.householdId, householdId),
+          gte(medicationLogs.loggedDate, from),
+          lte(medicationLogs.loggedDate, to)
+        )
+      ),
+    db
+      .select()
+      .from(activities)
+      .where(
+        and(
+          eq(activities.householdId, householdId),
+          gte(activities.completedAt, fromDate),
+          lte(activities.completedAt, toDate)
+        )
+      ),
+  ]);
+
+  // --- Feeding logs ---
+  if (fLogs.length > 0) {
+    const schedules = caches?.schedules ??
+      await db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, householdId));
     const scheduleMap = new Map(schedules.map((s) => [s.id, s.label]));
 
     for (const log of fLogs) {
@@ -62,22 +89,9 @@ export async function fetchUnifiedCompletions(
   }
 
   // --- Medication logs ---
-  const mLogs = await db
-    .select()
-    .from(medicationLogs)
-    .where(
-      and(
-        eq(medicationLogs.householdId, householdId),
-        gte(medicationLogs.loggedDate, from),
-        lte(medicationLogs.loggedDate, to)
-      )
-    );
-
   if (mLogs.length > 0) {
-    const meds = await db
-      .select()
-      .from(medications)
-      .where(eq(medications.householdId, householdId));
+    const meds = caches?.medications ??
+      await db.select().from(medications).where(eq(medications.householdId, householdId));
     const medMap = new Map(meds.map((m) => [m.id, { name: m.name, petId: m.petId }]));
 
     for (const log of mLogs) {
@@ -95,17 +109,6 @@ export async function fetchUnifiedCompletions(
   }
 
   // --- Activities (completed ones) ---
-  const completedActivities = await db
-    .select()
-    .from(activities)
-    .where(
-      and(
-        eq(activities.householdId, householdId),
-        gte(activities.completedAt, fromDate),
-        lte(activities.completedAt, toDate)
-      )
-    );
-
   for (const act of completedActivities) {
     if (act.completedAt && act.completedBy) {
       results.push({

--- a/apps/api/src/routers/calendar.ts
+++ b/apps/api/src/routers/calendar.ts
@@ -33,7 +33,7 @@ export const calendarRouter = router({
       const lastDay = monthEnd.getDate();
       const monthEndStr = `${month}-${String(lastDay).padStart(2, "0")}`;
 
-      const [monthActivities, schedules, logs, householdPets, householdMembers] =
+      const [monthActivities, schedules, logs, householdPets, householdMembers, monthHealthRecords] =
         await Promise.all([
           db
             .select()
@@ -66,6 +66,16 @@ export const calendarRouter = router({
             ),
           db.select().from(pets).where(eq(pets.householdId, householdId)),
           db.select().from(members).where(eq(members.householdId, householdId)),
+          db
+            .select()
+            .from(healthRecords)
+            .where(
+              and(
+                eq(healthRecords.householdId, householdId),
+                gte(healthRecords.date, monthStart),
+                lte(healthRecords.date, monthEnd)
+              )
+            ),
         ]);
 
       const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
@@ -125,17 +135,6 @@ export const calendarRouter = router({
       }
 
       // Add health records (vet visits, vaccinations, checkups, procedures)
-      const monthHealthRecords = await db
-        .select()
-        .from(healthRecords)
-        .where(
-          and(
-            eq(healthRecords.householdId, householdId),
-            gte(healthRecords.date, monthStart),
-            lte(healthRecords.date, monthEnd)
-          )
-        );
-
       for (const rec of monthHealthRecords) {
         const dateKey = rec.date.toISOString().split("T")[0];
         const label =

--- a/apps/api/src/routers/export.ts
+++ b/apps/api/src/routers/export.ts
@@ -77,25 +77,80 @@ export const exportRouter = router({
       memberRows.map((m) => [m.id, m.displayName])
     );
 
+    // Build lookup maps for O(1) grouping
+    const schedulesByPet = new Map<string, typeof feedingScheduleRows>();
+    for (const fs of feedingScheduleRows) {
+      const arr = schedulesByPet.get(fs.petId) ?? [];
+      arr.push(fs);
+      schedulesByPet.set(fs.petId, arr);
+    }
+
+    const logsBySchedule = new Map<string, typeof feedingLogRows>();
+    for (const fl of feedingLogRows) {
+      const arr = logsBySchedule.get(fl.feedingScheduleId) ?? [];
+      arr.push(fl);
+      logsBySchedule.set(fl.feedingScheduleId, arr);
+    }
+
+    const healthByPet = new Map<string, typeof healthRecordRows>();
+    for (const hr of healthRecordRows) {
+      const arr = healthByPet.get(hr.petId) ?? [];
+      arr.push(hr);
+      healthByPet.set(hr.petId, arr);
+    }
+
+    const medsByPet = new Map<string, typeof medicationRows>();
+    for (const med of medicationRows) {
+      const arr = medsByPet.get(med.petId) ?? [];
+      arr.push(med);
+      medsByPet.set(med.petId, arr);
+    }
+
+    const medLogsByMed = new Map<string, typeof medicationLogRows>();
+    for (const ml of medicationLogRows) {
+      const arr = medLogsByMed.get(ml.medicationId) ?? [];
+      arr.push(ml);
+      medLogsByMed.set(ml.medicationId, arr);
+    }
+
+    const activitiesByPet = new Map<string, typeof activityRows>();
+    for (const a of activityRows) {
+      const arr = activitiesByPet.get(a.petId) ?? [];
+      arr.push(a);
+      activitiesByPet.set(a.petId, arr);
+    }
+
+    const expensesByPet = new Map<string, typeof expenseRows>();
+    for (const e of expenseRows) {
+      if (!e.petId) continue;
+      const arr = expensesByPet.get(e.petId) ?? [];
+      arr.push(e);
+      expensesByPet.set(e.petId, arr);
+    }
+
+    const notesByPet = new Map<string, typeof noteRows>();
+    for (const n of noteRows) {
+      if (!n.petId) continue;
+      const arr = notesByPet.get(n.petId) ?? [];
+      arr.push(n);
+      notesByPet.set(n.petId, arr);
+    }
+
     // Group pet-related data by petId
     const petData = petRows.map((pet) => ({
       ...pet,
-      feedingSchedules: feedingScheduleRows
-        .filter((fs) => fs.petId === pet.id)
-        .map((fs) => ({
-          ...fs,
-          logs: feedingLogRows.filter((fl) => fl.feedingScheduleId === fs.id),
-        })),
-      healthRecords: healthRecordRows.filter((hr) => hr.petId === pet.id),
-      medications: medicationRows
-        .filter((med) => med.petId === pet.id)
-        .map((med) => ({
-          ...med,
-          logs: medicationLogRows.filter((ml) => ml.medicationId === med.id),
-        })),
-      activities: activityRows.filter((a) => a.petId === pet.id),
-      expenses: expenseRows.filter((e) => e.petId === pet.id),
-      notes: noteRows.filter((n) => n.petId === pet.id),
+      feedingSchedules: (schedulesByPet.get(pet.id) ?? []).map((fs) => ({
+        ...fs,
+        logs: logsBySchedule.get(fs.id) ?? [],
+      })),
+      healthRecords: healthByPet.get(pet.id) ?? [],
+      medications: (medsByPet.get(pet.id) ?? []).map((med) => ({
+        ...med,
+        logs: medLogsByMed.get(med.id) ?? [],
+      })),
+      activities: activitiesByPet.get(pet.id) ?? [],
+      expenses: expensesByPet.get(pet.id) ?? [],
+      notes: notesByPet.get(pet.id) ?? [],
       gamification: petGameRows.find((g) => g.petId === pet.id) ?? null,
     }));
 

--- a/apps/api/src/routers/finance.ts
+++ b/apps/api/src/routers/finance.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq, and, gte, lte } from "drizzle-orm";
 import { householdProcedure, router } from "../trpc.js";
 import {
   db,
@@ -96,18 +96,31 @@ export const financeRouter = router({
       const prevStart = new Date(year, month - 2, 1);
       const prevEnd = new Date(year, month - 1, 1);
 
-      // Fetch pets for name mapping
-      const householdPets = await db
-        .select()
-        .from(pets)
-        .where(eq(pets.householdId, ctx.householdId));
+      // Fetch pets, expenses, and health records in parallel with date filtering
+      const [householdPets, allExpenses, allHealth] = await Promise.all([
+        db.select().from(pets).where(eq(pets.householdId, ctx.householdId)),
+        db
+          .select()
+          .from(expenses)
+          .where(
+            and(
+              eq(expenses.householdId, ctx.householdId),
+              gte(expenses.date, prevStart),
+              lte(expenses.date, currentEnd)
+            )
+          ),
+        db
+          .select()
+          .from(healthRecords)
+          .where(
+            and(
+              eq(healthRecords.householdId, ctx.householdId),
+              gte(healthRecords.date, prevStart),
+              lte(healthRecords.date, currentEnd)
+            )
+          ),
+      ]);
       const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
-
-      // Fetch expenses for current + previous month
-      const allExpenses = await db
-        .select()
-        .from(expenses)
-        .where(eq(expenses.householdId, ctx.householdId));
 
       const currentExpenses = allExpenses.filter(
         (e) => new Date(e.date) >= currentStart && new Date(e.date) < currentEnd
@@ -115,12 +128,6 @@ export const financeRouter = router({
       const prevExpenses = allExpenses.filter(
         (e) => new Date(e.date) >= prevStart && new Date(e.date) < prevEnd
       );
-
-      // Fetch health records with cost for current + previous month
-      const allHealth = await db
-        .select()
-        .from(healthRecords)
-        .where(eq(healthRecords.householdId, ctx.householdId));
 
       const currentHealth = allHealth.filter(
         (h) => h.cost != null && h.cost > 0 && new Date(h.date) >= currentStart && new Date(h.date) < currentEnd

--- a/apps/api/src/routers/gamification.ts
+++ b/apps/api/src/routers/gamification.ts
@@ -8,6 +8,8 @@ import {
   petGameStats,
   pets,
   households,
+  feedingSchedules,
+  medications,
 } from "@petforce/db";
 import {
   GAMIFICATION_LEVELS,
@@ -207,12 +209,19 @@ export const gamificationRouter = router({
 
   recalculate: householdProcedure.mutation(async ({ ctx }) => {
     const today = new Date().toISOString().split("T")[0];
-    const raw = await fetchUnifiedCompletions(ctx.householdId, "2000-01-01", today);
 
-    const [householdMembers, petRows] = await Promise.all([
+    // Pre-fetch lookup data in parallel
+    const [householdMembers, petRows, schedules, meds] = await Promise.all([
       db.select().from(members).where(eq(members.householdId, ctx.householdId)),
       db.select().from(pets).where(eq(pets.householdId, ctx.householdId)),
+      db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, ctx.householdId)),
+      db.select().from(medications).where(eq(medications.householdId, ctx.householdId)),
     ]);
+
+    const raw = await fetchUnifiedCompletions(ctx.householdId, "2000-01-01", today, {
+      schedules,
+      medications: meds,
+    });
 
     // --- Accumulators ---
     const memberData = new Map<string, AccumulatorData>();

--- a/apps/api/src/routers/health.ts
+++ b/apps/api/src/routers/health.ts
@@ -340,22 +340,24 @@ export const healthRouter = router({
   summary: householdProcedure.query(async ({ ctx }) => {
     const now = new Date();
 
-    // Active medications count
-    const allMeds = await db
-      .select()
-      .from(medications)
-      .where(
-        and(
-          eq(medications.householdId, ctx.householdId),
-          eq(medications.isActive, true)
-        )
-      );
-
-    // Overdue vaccinations: type=vaccination AND nextDueDate < now
-    const allRecords = await db
-      .select()
-      .from(healthRecords)
-      .where(eq(healthRecords.householdId, ctx.householdId));
+    // Fetch medications, health records, and pets in parallel
+    const [allMeds, allRecords, householdPets] = await Promise.all([
+      db
+        .select()
+        .from(medications)
+        .where(
+          and(
+            eq(medications.householdId, ctx.householdId),
+            eq(medications.isActive, true)
+          )
+        ),
+      db
+        .select()
+        .from(healthRecords)
+        .where(eq(healthRecords.householdId, ctx.householdId)),
+      db.select().from(pets).where(eq(pets.householdId, ctx.householdId)),
+    ]);
+    const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
 
     const overdueVaccinations = allRecords.filter(
       (r) =>
@@ -380,11 +382,6 @@ export const healthRouter = router({
     let nextAppointment: HealthSummary["nextAppointment"] = null;
     if (futureAppointments.length > 0) {
       const appt = futureAppointments[0];
-      const householdPets = await db
-        .select()
-        .from(pets)
-        .where(eq(pets.householdId, ctx.householdId));
-      const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
       nextAppointment = {
         petName: petMap.get(appt.petId) ?? "Unknown",
         date: appt.date.toISOString(),

--- a/apps/api/src/routers/reporting.ts
+++ b/apps/api/src/routers/reporting.ts
@@ -25,12 +25,18 @@ export const reportingRouter = router({
   completionLog: householdProcedure
     .input(reportingCompletionLogSchema)
     .query(async ({ ctx, input }) => {
-      // Fetch completions and lookup data in parallel
-      const [raw, householdPets, householdMembers] = await Promise.all([
-        fetchUnifiedCompletions(ctx.householdId, input.from, input.to),
+      // Fetch lookup data in parallel, then pass caches to fetchUnifiedCompletions
+      const [householdPets, householdMembers, schedules, meds] = await Promise.all([
         db.select().from(pets).where(eq(pets.householdId, ctx.householdId)),
         db.select().from(members).where(eq(members.householdId, ctx.householdId)),
+        db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, ctx.householdId)),
+        db.select().from(medications).where(eq(medications.householdId, ctx.householdId)),
       ]);
+
+      const raw = await fetchUnifiedCompletions(ctx.householdId, input.from, input.to, {
+        schedules,
+        medications: meds,
+      });
 
       const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
       const memberMap = new Map(
@@ -77,16 +83,17 @@ export const reportingRouter = router({
   contributions: householdProcedure
     .input(reportDateRangeSchema)
     .query(async ({ ctx, input }) => {
-      const raw = await fetchUnifiedCompletions(
-        ctx.householdId,
-        input.from,
-        input.to
-      );
+      const [householdMembers, schedules, meds] = await Promise.all([
+        db.select().from(members).where(eq(members.householdId, ctx.householdId)),
+        db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, ctx.householdId)),
+        db.select().from(medications).where(eq(medications.householdId, ctx.householdId)),
+      ]);
 
-      const householdMembers = await db
-        .select()
-        .from(members)
-        .where(eq(members.householdId, ctx.householdId));
+      const raw = await fetchUnifiedCompletions(ctx.householdId, input.from, input.to, {
+        schedules,
+        medications: meds,
+      });
+
       const memberMap = new Map(
         householdMembers.map((m) => [m.id, m.displayName])
       );
@@ -151,11 +158,15 @@ export const reportingRouter = router({
   trends: householdProcedure
     .input(reportingTrendsSchema)
     .query(async ({ ctx, input }) => {
-      const raw = await fetchUnifiedCompletions(
-        ctx.householdId,
-        input.from,
-        input.to
-      );
+      const [schedules, meds] = await Promise.all([
+        db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, ctx.householdId)),
+        db.select().from(medications).where(eq(medications.householdId, ctx.householdId)),
+      ]);
+
+      const raw = await fetchUnifiedCompletions(ctx.householdId, input.from, input.to, {
+        schedules,
+        medications: meds,
+      });
 
       const granularity = input.granularity ?? "daily";
 
@@ -198,16 +209,17 @@ export const reportingRouter = router({
   summary: householdProcedure
     .input(reportDateRangeSchema)
     .query(async ({ ctx, input }) => {
-      const raw = await fetchUnifiedCompletions(
-        ctx.householdId,
-        input.from,
-        input.to
-      );
+      const [householdMembers, schedules, meds] = await Promise.all([
+        db.select().from(members).where(eq(members.householdId, ctx.householdId)),
+        db.select().from(feedingSchedules).where(eq(feedingSchedules.householdId, ctx.householdId)),
+        db.select().from(medications).where(eq(medications.householdId, ctx.householdId)),
+      ]);
 
-      const householdMembers = await db
-        .select()
-        .from(members)
-        .where(eq(members.householdId, ctx.householdId));
+      const raw = await fetchUnifiedCompletions(ctx.householdId, input.from, input.to, {
+        schedules,
+        medications: meds,
+      });
+
       const memberMap = new Map(
         householdMembers.map((m) => [m.id, m.displayName])
       );

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -2,7 +2,10 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
 
-const connectionString = process.env.DATABASE_URL!;
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL environment variable is required");
+}
 
 const client = postgres(connectionString, {
   max: parseInt(process.env.DATABASE_POOL_SIZE || "25"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       '@trpc/server':
         specifier: ^10.45.0
         version: 10.45.4
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.36.4)
+      '@upstash/redis':
+        specifier: ^1.36.4
+        version: 1.36.4
       drizzle-orm:
         specifier: ^0.33.0
         version: 0.33.0(@types/react@18.3.28)(postgres@3.4.8)(react@18.3.1)
@@ -3489,6 +3495,18 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.36.4':
+    resolution: {integrity: sha512-w4s/msmyMqxOxaVhC8TQ2whJ77+Zd8YaSFokXL4mULQopaYb4xNJcm/PedtFQyLJn65nneySw9IwYnlMBBmFHg==}
 
   '@urql/core@2.3.6':
     resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
@@ -7514,6 +7532,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -12992,6 +13013,19 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.36.4
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.36.4)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.36.4
+
+  '@upstash/redis@1.36.4':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@urql/core@2.3.6(graphql@15.8.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
@@ -17844,6 +17878,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary

Fixes three critical production issues: N+1 query patterns, missing env var validation, and distributed rate limiting.

**#28 - Fix N+1 query patterns:** Parallelize log fetches, add optional caches to `fetchUnifiedCompletions`, move sequential queries into Promise.all, replace O(n²) filtering with O(n) lookup maps, add WHERE clauses for date filtering.

**#29 - Env var validation:** Create Zod schema validating required vars (DATABASE_URL, Clerk auth, Supabase) at API startup; fail fast with clear errors instead of runtime crashes.

**#30 - Redis-backed rate limiting:** Integrate @upstash/ratelimit with granular limits (auth: 20, upload: 30, standard: 100 per 15min); falls back to in-memory when Redis unavailable.

## Test Plan

- Build passes (✓ all 6 packages)
- API startup validates env vars
- Rate limiter middleware active on `/trpc/*` and `/upload/*`
- Pre-fetched caches reduce DB queries in reporting/gamification procedures

🤖 Generated with [Claude Code](https://claude.com/claude-code)