### PR TITLE
Add unit tests for gamification and utilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "tsx dist/index.js",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run"
   },
   "dependencies": {
     "@clerk/backend": "^2.30.1",
@@ -30,6 +31,7 @@
     "@petforce/config": "workspace:*",
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/apps/api/src/lib/gamification-helpers.test.ts
+++ b/apps/api/src/lib/gamification-helpers.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  levelFromXp,
+  levelName,
+  nextLevelXp,
+  currentLevelXp,
+  computeStreaks,
+  buildLevelView,
+} from "./gamification-helpers";
+
+describe("levelFromXp", () => {
+  it("returns 1 for 0 XP", () => {
+    expect(levelFromXp(0)).toBe(1);
+  });
+
+  it("returns 1 for XP below level 2 threshold", () => {
+    expect(levelFromXp(59)).toBe(1);
+  });
+
+  it("returns 2 at exactly 60 XP (15 * 2^2)", () => {
+    expect(levelFromXp(60)).toBe(2);
+  });
+
+  it("returns 10 at 1500 XP", () => {
+    expect(levelFromXp(1500)).toBe(10);
+  });
+
+  it("returns 100 (max) for very high XP", () => {
+    expect(levelFromXp(999999)).toBe(100);
+  });
+
+  it("returns correct level at exact threshold boundaries", () => {
+    // Level 50 threshold: 15 * 50^2 = 37500
+    expect(levelFromXp(37500)).toBe(50);
+    expect(levelFromXp(37499)).toBe(49);
+  });
+});
+
+describe("levelName", () => {
+  it("returns dog track name for level 1", () => {
+    expect(levelName(1, "dog")).toBe("Puppy Pal");
+  });
+
+  it("returns member track name for level 1", () => {
+    expect(levelName(1, "member")).toBe("Helping Hand");
+  });
+
+  it("falls back to 'other' track when no track specified", () => {
+    expect(levelName(1)).toBe("Pet Pal");
+  });
+
+  it("falls back to 'other' track for unknown track", () => {
+    expect(levelName(1, "hamster")).toBe("Pet Pal");
+  });
+
+  it("returns 'Level N' for out-of-range level", () => {
+    expect(levelName(101, "dog")).toBe("Level 101");
+  });
+});
+
+describe("nextLevelXp", () => {
+  it("returns level 2 threshold for level 1", () => {
+    expect(nextLevelXp(1)).toBe(60);
+  });
+
+  it("returns max level threshold for level 100 (no next level)", () => {
+    expect(nextLevelXp(100)).toBe(150000);
+  });
+});
+
+describe("currentLevelXp", () => {
+  it("returns 0 for level 1", () => {
+    expect(currentLevelXp(1)).toBe(0);
+  });
+
+  it("returns 60 for level 2", () => {
+    expect(currentLevelXp(2)).toBe(60);
+  });
+
+  it("returns 0 for invalid level", () => {
+    expect(currentLevelXp(0)).toBe(0);
+  });
+});
+
+describe("computeStreaks", () => {
+  it("returns zeros for empty set", () => {
+    expect(computeStreaks(new Set(), "2026-03-12")).toEqual({
+      currentStreak: 0,
+      longestStreak: 0,
+      lastDay: null,
+    });
+  });
+
+  it("returns streak of 1 for single day that is today", () => {
+    const result = computeStreaks(new Set(["2026-03-12"]), "2026-03-12");
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+    expect(result.lastDay).toBe("2026-03-12");
+  });
+
+  it("returns streak of 1 for single day that is yesterday", () => {
+    const result = computeStreaks(new Set(["2026-03-11"]), "2026-03-12");
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it("returns currentStreak 0 when last active day is more than 1 day ago", () => {
+    const result = computeStreaks(new Set(["2026-03-10"]), "2026-03-12");
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it("computes 3-day consecutive streak", () => {
+    const days = new Set(["2026-03-10", "2026-03-11", "2026-03-12"]);
+    const result = computeStreaks(days, "2026-03-12");
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it("preserves longest streak after a gap", () => {
+    const days = new Set([
+      "2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05",
+      // gap
+      "2026-03-10", "2026-03-11", "2026-03-12",
+    ]);
+    const result = computeStreaks(days, "2026-03-12");
+    expect(result.longestStreak).toBe(5);
+    expect(result.currentStreak).toBe(3);
+  });
+
+  it("handles unordered input (sorts internally)", () => {
+    const days = new Set(["2026-03-12", "2026-03-10", "2026-03-11"]);
+    const result = computeStreaks(days, "2026-03-12");
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+});
+
+describe("buildLevelView", () => {
+  it("returns correct view for 0 XP", () => {
+    const view = buildLevelView(0, "dog");
+    expect(view.level).toBe(1);
+    expect(view.levelName).toBe("Puppy Pal");
+    expect(view.xpToNextLevel).toBe(60); // 60 - 0
+    expect(view.nextLevelXp).toBe(60);   // 60 - 0
+  });
+
+  it("returns correct view mid-level", () => {
+    const view = buildLevelView(30, "member");
+    expect(view.level).toBe(1);
+    expect(view.xpToNextLevel).toBe(30); // 60 - 30
+  });
+
+  it("returns correct view at max level", () => {
+    const view = buildLevelView(150000, "cat");
+    expect(view.level).toBe(100);
+    expect(view.xpToNextLevel).toBe(0);
+  });
+});

--- a/apps/api/src/lib/gamification-helpers.ts
+++ b/apps/api/src/lib/gamification-helpers.ts
@@ -1,0 +1,85 @@
+import { GAMIFICATION_LEVELS, GAMIFICATION_LEVEL_NAMES } from "@petforce/core";
+
+export function levelFromXp(xp: number): number {
+  for (let i = GAMIFICATION_LEVELS.length - 1; i >= 0; i--) {
+    if (xp >= GAMIFICATION_LEVELS[i].xpThreshold) return GAMIFICATION_LEVELS[i].level;
+  }
+  return 1;
+}
+
+export function levelName(level: number, track?: string): string {
+  if (track) {
+    const names = GAMIFICATION_LEVEL_NAMES[track];
+    if (names && names[level - 1]) return names[level - 1];
+  }
+  const otherNames = GAMIFICATION_LEVEL_NAMES["other"];
+  return (otherNames && otherNames[level - 1]) ?? `Level ${level}`;
+}
+
+export function nextLevelXp(level: number): number {
+  const next = GAMIFICATION_LEVELS.find((l) => l.level === level + 1);
+  return next ? next.xpThreshold : GAMIFICATION_LEVELS[GAMIFICATION_LEVELS.length - 1].xpThreshold;
+}
+
+export function currentLevelXp(level: number): number {
+  return GAMIFICATION_LEVELS.find((l) => l.level === level)?.xpThreshold ?? 0;
+}
+
+export function computeStreaks(
+  activeDays: Set<string>,
+  today: string
+): { currentStreak: number; longestStreak: number; lastDay: string | null } {
+  const sortedDays = Array.from(activeDays).sort();
+  if (sortedDays.length === 0) {
+    return { currentStreak: 0, longestStreak: 0, lastDay: null };
+  }
+
+  let longestStreak = 1;
+  let streakCount = 1;
+
+  for (let i = 1; i < sortedDays.length; i++) {
+    const prev = new Date(sortedDays[i - 1]);
+    const curr = new Date(sortedDays[i]);
+    const diffDays = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+    if (diffDays === 1) {
+      streakCount++;
+    } else {
+      streakCount = 1;
+    }
+    if (streakCount > longestStreak) longestStreak = streakCount;
+  }
+
+  const lastDay = sortedDays[sortedDays.length - 1];
+  let currentStreak = 0;
+
+  const lastDate = new Date(lastDay);
+  const todayDate = new Date(today);
+  const diffDays = (todayDate.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays <= 1) {
+    currentStreak = 1;
+    for (let i = sortedDays.length - 2; i >= 0; i--) {
+      const prev = new Date(sortedDays[i]);
+      const curr = new Date(sortedDays[i + 1]);
+      const d = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+      if (d === 1) {
+        currentStreak++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return { currentStreak, longestStreak, lastDay };
+}
+
+export function buildLevelView(xp: number, track?: string) {
+  const lvl = levelFromXp(xp);
+  const nxtXp = nextLevelXp(lvl);
+  const curXp = currentLevelXp(lvl);
+  return {
+    level: lvl,
+    levelName: levelName(lvl, track),
+    xpToNextLevel: nxtXp - xp,
+    nextLevelXp: nxtXp - curXp,
+  };
+}

--- a/apps/api/src/routers/gamification.ts
+++ b/apps/api/src/routers/gamification.ts
@@ -12,8 +12,6 @@ import {
   medications,
 } from "@petforce/db";
 import {
-  GAMIFICATION_LEVELS,
-  GAMIFICATION_LEVEL_NAMES,
   GAMIFICATION_XP_VALUES,
   evaluateBadges,
 } from "@petforce/core";
@@ -24,90 +22,7 @@ import type {
   GamificationFullStats,
 } from "@petforce/core";
 import { fetchUnifiedCompletions } from "../lib/unified-completions.js";
-
-function levelFromXp(xp: number): number {
-  for (let i = GAMIFICATION_LEVELS.length - 1; i >= 0; i--) {
-    if (xp >= GAMIFICATION_LEVELS[i].xpThreshold) return GAMIFICATION_LEVELS[i].level;
-  }
-  return 1;
-}
-
-function levelName(level: number, track?: string): string {
-  if (track) {
-    const names = GAMIFICATION_LEVEL_NAMES[track];
-    if (names && names[level - 1]) return names[level - 1];
-  }
-  const otherNames = GAMIFICATION_LEVEL_NAMES["other"];
-  return (otherNames && otherNames[level - 1]) ?? `Level ${level}`;
-}
-
-function nextLevelXp(level: number): number {
-  const next = GAMIFICATION_LEVELS.find((l) => l.level === level + 1);
-  return next ? next.xpThreshold : GAMIFICATION_LEVELS[GAMIFICATION_LEVELS.length - 1].xpThreshold;
-}
-
-function currentLevelXp(level: number): number {
-  return GAMIFICATION_LEVELS.find((l) => l.level === level)?.xpThreshold ?? 0;
-}
-
-function computeStreaks(
-  activeDays: Set<string>,
-  today: string
-): { currentStreak: number; longestStreak: number; lastDay: string | null } {
-  const sortedDays = Array.from(activeDays).sort();
-  if (sortedDays.length === 0) {
-    return { currentStreak: 0, longestStreak: 0, lastDay: null };
-  }
-
-  let longestStreak = 1;
-  let streakCount = 1;
-
-  for (let i = 1; i < sortedDays.length; i++) {
-    const prev = new Date(sortedDays[i - 1]);
-    const curr = new Date(sortedDays[i]);
-    const diffDays = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
-    if (diffDays === 1) {
-      streakCount++;
-    } else {
-      streakCount = 1;
-    }
-    if (streakCount > longestStreak) longestStreak = streakCount;
-  }
-
-  const lastDay = sortedDays[sortedDays.length - 1];
-  let currentStreak = 0;
-
-  const lastDate = new Date(lastDay);
-  const todayDate = new Date(today);
-  const diffDays = (todayDate.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24);
-  if (diffDays <= 1) {
-    currentStreak = 1;
-    for (let i = sortedDays.length - 2; i >= 0; i--) {
-      const prev = new Date(sortedDays[i]);
-      const curr = new Date(sortedDays[i + 1]);
-      const d = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
-      if (d === 1) {
-        currentStreak++;
-      } else {
-        break;
-      }
-    }
-  }
-
-  return { currentStreak, longestStreak, lastDay };
-}
-
-function buildLevelView(xp: number, track?: string) {
-  const lvl = levelFromXp(xp);
-  const nxtXp = nextLevelXp(lvl);
-  const curXp = currentLevelXp(lvl);
-  return {
-    level: lvl,
-    levelName: levelName(lvl, track),
-    xpToNextLevel: nxtXp - xp,
-    nextLevelXp: nxtXp - curXp,
-  };
-}
+import { levelFromXp, buildLevelView, computeStreaks } from "../lib/gamification-helpers.js";
 
 interface AccumulatorData {
   totalXp: number;

--- a/apps/api/src/utils/join-code.test.ts
+++ b/apps/api/src/utils/join-code.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { generateJoinCode, generateInviteToken } from "./join-code";
+
+describe("generateJoinCode", () => {
+  it("returns format XXX-NNNN (3 letters, dash, 4 digits)", () => {
+    const code = generateJoinCode();
+    expect(code).toMatch(/^[A-Z]{3}-\d{4}$/);
+  });
+
+  it("excludes I and O from letters", () => {
+    // Generate many codes to statistically verify I and O are excluded
+    const codes = Array.from({ length: 100 }, () => generateJoinCode());
+    const allLetters = codes.map((c) => c.slice(0, 3)).join("");
+    expect(allLetters).not.toContain("I");
+    expect(allLetters).not.toContain("O");
+  });
+
+  it("produces different codes on successive calls", () => {
+    const codes = new Set(Array.from({ length: 20 }, () => generateJoinCode()));
+    expect(codes.size).toBeGreaterThan(1);
+  });
+});
+
+describe("generateInviteToken", () => {
+  it("returns a base64url string", () => {
+    const token = generateInviteToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("has expected length for 24 random bytes encoded as base64url", () => {
+    const token = generateInviteToken();
+    // 24 bytes -> 32 base64url chars
+    expect(token).toHaveLength(32);
+  });
+
+  it("produces unique tokens", () => {
+    const tokens = new Set(Array.from({ length: 20 }, () => generateInviteToken()));
+    expect(tokens.size).toBe(20);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@petforce/core": path.resolve(__dirname, "../../packages/core/src/index.ts"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+    },
+  },
+});

--- a/packages/core/src/gamification-badges.test.ts
+++ b/packages/core/src/gamification-badges.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  GAMIFICATION_BADGES,
+  BADGE_CATEGORIES,
+  evaluateBadges,
+} from "./gamification-badges";
+
+describe("GAMIFICATION_BADGES data integrity", () => {
+  it("has no duplicate badge IDs", () => {
+    const ids = GAMIFICATION_BADGES.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every badge has at least one rule", () => {
+    for (const badge of GAMIFICATION_BADGES) {
+      expect(badge.rules.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("every badge belongs to a valid group", () => {
+    const validGroups = ["member", "household", "pet"];
+    for (const badge of GAMIFICATION_BADGES) {
+      expect(validGroups).toContain(badge.group);
+    }
+  });
+
+  it("every badge has a category from BADGE_CATEGORIES", () => {
+    const cats = BADGE_CATEGORIES as readonly string[];
+    for (const badge of GAMIFICATION_BADGES) {
+      expect(cats).toContain(badge.category);
+    }
+  });
+
+  it("has member, household, and pet badges", () => {
+    const groups = new Set(GAMIFICATION_BADGES.map((b) => b.group));
+    expect(groups).toEqual(new Set(["member", "household", "pet"]));
+  });
+});
+
+describe("evaluateBadges", () => {
+  const zeroStats = {
+    totalTasks: 0,
+    feedingCount: 0,
+    medicationCount: 0,
+    activityCount: 0,
+    longestStreak: 0,
+    level: 1,
+  };
+
+  it("returns empty array when all stats are zero", () => {
+    expect(evaluateBadges("member", zeroStats)).toEqual([]);
+  });
+
+  it("returns first_steps when totalTasks >= 1 for member", () => {
+    const result = evaluateBadges("member", { ...zeroStats, totalTasks: 1 });
+    expect(result).toContain("first_steps");
+  });
+
+  it("returns multiple milestone badges for high totalTasks", () => {
+    const result = evaluateBadges("member", { ...zeroStats, totalTasks: 100 });
+    expect(result).toContain("first_steps");
+    expect(result).toContain("high_five");
+    expect(result).toContain("double_digits");
+    expect(result).toContain("quarter_century");
+    expect(result).toContain("half_century");
+    expect(result).toContain("century_club");
+    expect(result).not.toContain("power_250");
+  });
+
+  it("does not return member badges for pet group", () => {
+    const result = evaluateBadges("pet", { ...zeroStats, totalTasks: 1000 });
+    expect(result).not.toContain("first_steps");
+    expect(result).toContain("first_care");
+  });
+
+  it("evaluates feeding badges independently", () => {
+    const result = evaluateBadges("member", { ...zeroStats, feedingCount: 10 });
+    expect(result).toContain("first_feeding");
+    expect(result).toContain("feeding_frenzy");
+    expect(result).not.toContain("feeding_pro");
+  });
+
+  it("evaluates streak badges", () => {
+    const result = evaluateBadges("member", { ...zeroStats, longestStreak: 7 });
+    expect(result).toContain("three_day_streak");
+    expect(result).toContain("week_warrior");
+    expect(result).not.toContain("fortnight_hero");
+  });
+
+  it("evaluates level badges", () => {
+    const result = evaluateBadges("member", { ...zeroStats, level: 10 });
+    expect(result).toContain("pet_parent_pro");
+    expect(result).toContain("level_10_member");
+    expect(result).not.toContain("level_25_member");
+  });
+
+  it("evaluates household badges with activeMemberCount", () => {
+    const result = evaluateBadges("household", {
+      ...zeroStats,
+      totalTasks: 1,
+      activeMemberCount: 3,
+    });
+    expect(result).toContain("house_warming");
+    expect(result).toContain("duo_house");
+    expect(result).toContain("full_house");
+    expect(result).not.toContain("fab_five");
+  });
+
+  it("defaults activeMemberCount to 0 when omitted", () => {
+    const result = evaluateBadges("household", { ...zeroStats, totalTasks: 1 });
+    expect(result).toContain("house_warming");
+    expect(result).not.toContain("duo_house");
+  });
+});

--- a/packages/core/src/gamification-levels.test.ts
+++ b/packages/core/src/gamification-levels.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { GAMIFICATION_LEVELS, GAMIFICATION_LEVEL_NAMES } from "./gamification-levels";
+
+describe("GAMIFICATION_LEVELS", () => {
+  it("has exactly 100 levels", () => {
+    expect(GAMIFICATION_LEVELS).toHaveLength(100);
+  });
+
+  it("level 1 has threshold 0", () => {
+    expect(GAMIFICATION_LEVELS[0].level).toBe(1);
+    expect(GAMIFICATION_LEVELS[0].xpThreshold).toBe(0);
+  });
+
+  it("thresholds are monotonically increasing", () => {
+    for (let i = 1; i < GAMIFICATION_LEVELS.length; i++) {
+      expect(GAMIFICATION_LEVELS[i].xpThreshold).toBeGreaterThan(
+        GAMIFICATION_LEVELS[i - 1].xpThreshold
+      );
+    }
+  });
+
+  it("XP formula matches round(15 * level^2) for spot-checked levels", () => {
+    // Level 2: round(15 * 4) = 60
+    expect(GAMIFICATION_LEVELS[1].xpThreshold).toBe(60);
+    // Level 10: round(15 * 100) = 1500
+    expect(GAMIFICATION_LEVELS[9].xpThreshold).toBe(1500);
+    // Level 50: round(15 * 2500) = 37500
+    expect(GAMIFICATION_LEVELS[49].xpThreshold).toBe(37500);
+    // Level 100: round(15 * 10000) = 150000
+    expect(GAMIFICATION_LEVELS[99].xpThreshold).toBe(150000);
+  });
+});
+
+describe("GAMIFICATION_LEVEL_NAMES", () => {
+  const expectedTracks = ["member", "household", "dog", "cat", "bird", "fish", "reptile", "other"];
+
+  it("has entries for all 8 tracks", () => {
+    for (const track of expectedTracks) {
+      expect(GAMIFICATION_LEVEL_NAMES).toHaveProperty(track);
+    }
+  });
+
+  it("each track has exactly 100 names", () => {
+    for (const track of expectedTracks) {
+      expect(GAMIFICATION_LEVEL_NAMES[track]).toHaveLength(100);
+    }
+  });
+
+  it("no track has empty name strings", () => {
+    for (const track of expectedTracks) {
+      for (const name of GAMIFICATION_LEVEL_NAMES[track]) {
+        expect(name.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.32)(terser@5.46.0)
 
   apps/mobile:
     dependencies:
@@ -1870,7 +1873,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -14458,8 +14461,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -14482,7 +14485,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14493,22 +14496,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14519,7 +14522,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
Add 47 new unit tests covering gamification badges, levels, and pure helper functions. Extract 5 gamification helper functions from router into testable library, improving code reusability and enabling isolation testing without DB mocking.

## Changes
- **Gamification badges tests** — badge data integrity, `evaluateBadges` logic for member/household/pet groups, rule evaluation
- **Gamification levels tests** — 100-level count, XP formula (15×level²), threshold ordering, 8 track names
- **Join-code utility tests** — format validation (XXX-NNNN), I/O exclusion, invite token randomness
- **Gamification helpers tests** — levelFromXp, levelName, computeStreaks, buildLevelView with 26 edge case tests
- **Infrastructure** — vitest configs for both packages/core and apps/api, helpers extraction refactor

## Test Results
- Core: 82 tests (61 schemas + 21 gamification)
- API: 32 tests (6 utilities + 26 helpers)
- All passing ✓

🤖 Generated with Claude Code