### PR TITLE
Add connection pool and query timeout configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ API_PORT=3001
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_WEB_URL=http://localhost:3000
 
+# Database Pool (optional — sensible defaults based on NODE_ENV)
+# DATABASE_POOL_SIZE=20
+# DB_STATEMENT_TIMEOUT=30000
+
 # Rate Limiting (optional — falls back to in-memory if not set)
 UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your_token

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -7,8 +7,18 @@ if (!connectionString) {
   throw new Error("DATABASE_URL environment variable is required");
 }
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const client = postgres(connectionString, {
-  max: parseInt(process.env.DATABASE_POOL_SIZE || "25"),
+  max: parseInt(process.env.DATABASE_POOL_SIZE || (isProduction ? "20" : "5")),
+  idle_timeout: 20,
+  connect_timeout: 10,
+  max_lifetime: 60 * 30,
+  connection: {
+    application_name: "petforce-api",
+    statement_timeout: parseInt(process.env.DB_STATEMENT_TIMEOUT || "30000"),
+  },
+  onnotice: () => {},
 });
 
 export const db = drizzle(client, { schema });
@@ -17,5 +27,5 @@ export type Database = typeof db;
 
 /** Close the database connection pool. Call during graceful shutdown. */
 export async function closeConnection() {
-  await client.end();
+  await client.end({ timeout: 5 });
 }


### PR DESCRIPTION
## Summary
- Add environment-aware pool sizing (20 prod / 5 dev, down from flat 25)
- Add idle_timeout (20s), connect_timeout (10s), max_lifetime (30 min) for proper connection recycling
- Add statement_timeout (30s default, configurable) to prevent runaway queries from blocking connections indefinitely
- Set application_name for connection identification in pg_stat_activity
- Add 5s timeout to graceful shutdown to prevent hanging
- Document new optional env vars in .env.example

## Why
Fixes Issue #36 — Prevents single slow query from exhausting the pool, ensures reliable connection cleanup, and improves observability of database connections in production.

🤖 Generated with Claude Code