### PR TITLE
Add file magic byte validation for uploads — Issue #34

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,15 +21,16 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.4",
     "drizzle-orm": "^0.33.0",
+    "file-type": "^21.3.1",
     "hono": "^4.5.0",
     "pino": "^9.6.0",
     "superjson": "^2.2.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "pino-pretty": "^13.0.0",
     "@petforce/config": "workspace:*",
     "@types/node": "^20.14.0",
+    "pino-pretty": "^13.0.0",
     "tsx": "^4.16.0",
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"

--- a/apps/api/src/lib/validate-file-type.test.ts
+++ b/apps/api/src/lib/validate-file-type.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { validateFileMagicBytes } from "./validate-file-type.js";
+
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
+// Minimal valid file headers (magic bytes)
+// JPEG: FF D8 FF
+const JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+// PNG: signature + minimal IHDR chunk
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+  0x00, 0x00, 0x00, 0x0d, // IHDR chunk length (13)
+  0x49, 0x48, 0x44, 0x52, // "IHDR"
+  0x00, 0x00, 0x00, 0x01, // width: 1
+  0x00, 0x00, 0x00, 0x01, // height: 1
+  0x08, 0x02, 0x00, 0x00, 0x00, // bit depth, color type, etc.
+  0x90, 0x77, 0x53, 0xde, // CRC
+]);
+// WebP: RIFF....WEBP
+const WEBP_HEADER = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, // RIFF
+  0x00, 0x00, 0x00, 0x00, // file size (placeholder)
+  0x57, 0x45, 0x42, 0x50, // WEBP
+]);
+// PDF: %PDF
+const PDF_HEADER = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+
+describe("validateFileMagicBytes", () => {
+  it("accepts a valid JPEG buffer", async () => {
+    const result = await validateFileMagicBytes(JPEG_HEADER, ALLOWED_IMAGE_TYPES);
+    expect(result).toBe("image/jpeg");
+  });
+
+  it("accepts a valid PNG buffer", async () => {
+    const result = await validateFileMagicBytes(PNG_HEADER, ALLOWED_IMAGE_TYPES);
+    expect(result).toBe("image/png");
+  });
+
+  it("accepts a valid WebP buffer", async () => {
+    const result = await validateFileMagicBytes(WEBP_HEADER, ALLOWED_IMAGE_TYPES);
+    expect(result).toBe("image/webp");
+  });
+
+  it("rejects a PDF disguised with image extension", async () => {
+    const result = await validateFileMagicBytes(PDF_HEADER, ALLOWED_IMAGE_TYPES);
+    expect(result).toBeNull();
+  });
+
+  it("rejects an empty buffer", async () => {
+    const result = await validateFileMagicBytes(Buffer.alloc(0), ALLOWED_IMAGE_TYPES);
+    expect(result).toBeNull();
+  });
+
+  it("rejects random bytes", async () => {
+    const random = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
+    const result = await validateFileMagicBytes(random, ALLOWED_IMAGE_TYPES);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a valid file type not in the allowed list", async () => {
+    // PDF is a valid file type but not in our allowed image types
+    const result = await validateFileMagicBytes(PDF_HEADER, ["image/jpeg"]);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/lib/validate-file-type.ts
+++ b/apps/api/src/lib/validate-file-type.ts
@@ -1,0 +1,22 @@
+import { fileTypeFromBuffer } from "file-type";
+
+/**
+ * Validates a file buffer's magic bytes against a list of allowed MIME types.
+ * Returns the detected MIME type if valid, or null if invalid/undetectable.
+ */
+export async function validateFileMagicBytes(
+  buffer: Buffer,
+  allowedTypes: readonly string[]
+): Promise<string | null> {
+  const result = await fileTypeFromBuffer(buffer);
+
+  if (!result) {
+    return null;
+  }
+
+  if (!allowedTypes.includes(result.mime)) {
+    return null;
+  }
+
+  return result.mime;
+}

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -10,6 +10,7 @@ import {
 } from "@petforce/core";
 import { verifyClerkToken } from "../lib/clerk-auth.js";
 import { uploadPetAvatar, uploadPetPhoto } from "../lib/supabase-storage.js";
+import { validateFileMagicBytes } from "../lib/validate-file-type.js";
 
 const uploadApp = new Hono();
 
@@ -63,9 +64,18 @@ uploadApp.post("/pet-avatar", async (c) => {
     return c.json({ error: "You are not a member of this pet's household" }, 403);
   }
 
-  // --- Upload to Supabase Storage ---
+  // --- Validate file magic bytes ---
   const buffer = Buffer.from(await file.arrayBuffer());
-  const avatarUrl = await uploadPetAvatar(pet.householdId, petId, buffer, file.type);
+  const detectedMime = await validateFileMagicBytes(buffer, PET_AVATAR_ALLOWED_TYPES);
+  if (!detectedMime) {
+    return c.json(
+      { error: `File content does not match an allowed image type. Allowed: ${PET_AVATAR_ALLOWED_TYPES.join(", ")}` },
+      400
+    );
+  }
+
+  // --- Upload to Supabase Storage ---
+  const avatarUrl = await uploadPetAvatar(pet.householdId, petId, buffer, detectedMime);
 
   // --- Update pet record ---
   await db
@@ -157,7 +167,16 @@ uploadApp.post("/pet-photo", async (c) => {
   // --- Upload to Supabase Storage ---
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
-    const url = await uploadPetPhoto(pet.householdId, petId, photo.id, buffer, file.type);
+    const detectedMime = await validateFileMagicBytes(buffer, PET_PHOTO_ALLOWED_TYPES);
+    if (!detectedMime) {
+      // Clean up the DB record since we're rejecting the file
+      await db.delete(petPhotos).where(eq(petPhotos.id, photo.id));
+      return c.json(
+        { error: `File content does not match an allowed image type. Allowed: ${PET_PHOTO_ALLOWED_TYPES.join(", ")}` },
+        400
+      );
+    }
+    const url = await uploadPetPhoto(pet.householdId, petId, photo.id, buffer, detectedMime);
 
     // Update record with real URL
     const [updated] = await db

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       drizzle-orm:
         specifier: ^0.33.0
         version: 0.33.0(@types/react@18.3.28)(postgres@3.4.8)(react@18.3.1)
+      file-type:
+        specifier: ^21.3.1
+        version: 21.3.1
       hono:
         specifier: ^4.5.0
         version: 4.11.8
@@ -1071,6 +1074,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@clerk/backend@2.30.1':
     resolution: {integrity: sha512-GoxnJzVH0ycNPAGCDMfo3lPBFbo5nehpLSVFjgGEnzIRGGahBtAB8PQT7KM2zo58pD8apjb/+suhcB/WCiEasQ==}
@@ -3258,6 +3264,13 @@ packages:
       react-native:
         optional: true
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@trpc/client@10.45.4':
     resolution: {integrity: sha512-ItpH5FMIJFt862kbAgC8hf5NJnDLo0FwEvMEX6zSLCenzWD0UH6H/fvAX1suFo1e0wcAmMhiEU1Tl6xKk/Pd1g==}
     peerDependencies:
@@ -4996,6 +5009,10 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
+
+  file-type@21.3.1:
+    resolution: {integrity: sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==}
+    engines: {node: '>=20'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -7303,6 +7320,10 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
@@ -7490,6 +7511,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -7618,6 +7643,10 @@ packages:
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -9014,6 +9043,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@clerk/backend@2.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -12854,6 +12885,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@trpc/client@10.45.4(@trpc/server@10.45.4)':
     dependencies:
       '@trpc/server': 10.45.4
@@ -14899,6 +14939,15 @@ snapshots:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.105.0(esbuild@0.25.12)
+
+  file-type@21.3.1:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.1.1:
     dependencies:
@@ -17598,6 +17647,10 @@ snapshots:
 
   strnum@1.1.2: {}
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   structured-headers@0.4.1: {}
 
   style-value-types@5.0.0:
@@ -17915,6 +17968,12 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   tr46@0.0.3: {}
 
   traverse@0.6.11:
@@ -18041,6 +18100,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ua-parser-js@1.0.41: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Added server-side file content validation using the `file-type` package to prevent MIME type spoofing
- Both `/pet-avatar` and `/pet-photo` endpoints now inspect magic bytes instead of trusting client-provided MIME types
- Blocks uploads of malicious files (e.g., HTML/SVG) disguised as images, preventing XSS attacks
- Uses detected MIME type for storage instead of client-provided value

## Security Impact
- **Before:** Client could upload `malicious.html` with `Content-Type: image/jpeg` to bypass client-side validation
- **After:** Server inspects file magic bytes (header signatures); detected type must match an allowed image type (JPEG, PNG, WebP)

## Testing
- 7 unit tests added covering JPEG, PNG, WebP detection and PDF/empty/random/disallowed type rejection
- All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)