### PR TITLE
Add global error handling middleware (#39)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { env } from "./lib/env.js";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
 import { serve } from "@hono/node-server";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter } from "./router.js";
@@ -10,7 +11,38 @@ import uploadApp from "./routes/upload.js";
 import { logger } from "./lib/logger.js";
 import type { Context } from "./trpc.js";
 
+const isProd = process.env.NODE_ENV === "production";
+
 const app = new Hono();
+
+// --- Global error handler ---
+app.onError((err, c) => {
+  // Hono HTTPExceptions are intentional — preserve their status and message
+  if (err instanceof HTTPException) {
+    logger.warn(
+      { status: err.status, message: err.message, path: c.req.path },
+      "HTTP exception"
+    );
+    return c.json({ error: err.message }, err.status);
+  }
+
+  // Log the full error internally
+  logger.error(
+    { err, method: c.req.method, path: c.req.path },
+    "Unhandled error"
+  );
+
+  // Never leak stack traces or internal details to clients
+  return c.json(
+    { error: isProd ? "Internal server error" : err.message },
+    500
+  );
+});
+
+// --- 404 handler ---
+app.notFound((c) => {
+  return c.json({ error: "Not found" }, 404);
+});
 
 // --- Request logging ---
 app.use("/*", async (c, next) => {
@@ -79,3 +111,13 @@ async function shutdown(signal: string) {
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));
+
+// --- Unhandled rejection / exception safety net ---
+process.on("unhandledRejection", (reason) => {
+  logger.error({ err: reason }, "Unhandled promise rejection");
+});
+
+process.on("uncaughtException", (err) => {
+  logger.fatal({ err }, "Uncaught exception — shutting down");
+  shutdown("uncaughtException");
+});


### PR DESCRIPTION
## Summary
- Add Hono `onError` handler to catch unhandled errors from all routes (upload, custom routes)
- Add 404 handler returning clean JSON responses
- Add process-level `unhandledRejection` and `uncaughtException` handlers
- Prevent stack trace and internal error details from leaking to clients in production

Resolves Issue #39 (P2 Security/Reliability). Upload routes and non-tRPC endpoints are now protected with error boundaries that log full details internally but return sanitized responses to clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)