### PR TITLE
Fix N+1 query patterns in API routers (#28)

### DIFF
--- a/apps/api/src/routers/calendar.ts
+++ b/apps/api/src/routers/calendar.ts
@@ -366,26 +366,28 @@ export const calendarRouter = router({
       }
 
       // Add upcoming pet holidays (next 7 days)
+      const holidayMap = new Map(
+        PET_HOLIDAYS.map((h) => [`${h.month}-${h.day}`, h])
+      );
       for (let d = 0; d <= 7; d++) {
         const futureDate = new Date(now.getTime() + d * 86400000);
         const fMonth = futureDate.getMonth() + 1;
         const fDay = futureDate.getDate();
-        const dateStr = `${futureDate.getFullYear()}-${String(fMonth).padStart(2, "0")}-${String(fDay).padStart(2, "0")}`;
-        for (const holiday of PET_HOLIDAYS) {
-          if (holiday.month === fMonth && holiday.day === fDay) {
-            events.push({
-              id: `holiday-${holiday.month}-${holiday.day}`,
-              kind: "holiday",
-              title: holiday.name,
-              petId: "",
-              petName: "",
-              memberId: null,
-              memberName: null,
-              type: "holiday",
-              scheduledAt: `${dateStr}T00:00:00`,
-              completedAt: null,
-            });
-          }
+        const holiday = holidayMap.get(`${fMonth}-${fDay}`);
+        if (holiday) {
+          const dateStr = `${futureDate.getFullYear()}-${String(fMonth).padStart(2, "0")}-${String(fDay).padStart(2, "0")}`;
+          events.push({
+            id: `holiday-${holiday.month}-${holiday.day}`,
+            kind: "holiday",
+            title: holiday.name,
+            petId: "",
+            petName: "",
+            memberId: null,
+            memberName: null,
+            type: "holiday",
+            scheduledAt: `${dateStr}T00:00:00`,
+            completedAt: null,
+          });
         }
       }
 

--- a/apps/api/src/routers/export.ts
+++ b/apps/api/src/routers/export.ts
@@ -136,6 +136,9 @@ export const exportRouter = router({
       notesByPet.set(n.petId, arr);
     }
 
+    // Build O(1) lookup for pet game stats
+    const petGameMap = new Map(petGameRows.map((g) => [g.petId, g]));
+
     // Group pet-related data by petId
     const petData = petRows.map((pet) => ({
       ...pet,
@@ -151,7 +154,7 @@ export const exportRouter = router({
       activities: activitiesByPet.get(pet.id) ?? [],
       expenses: expensesByPet.get(pet.id) ?? [],
       notes: notesByPet.get(pet.id) ?? [],
-      gamification: petGameRows.find((g) => g.petId === pet.id) ?? null,
+      gamification: petGameMap.get(pet.id) ?? null,
     }));
 
     // Household-level notes (no pet attached)

--- a/apps/api/src/routers/finance.ts
+++ b/apps/api/src/routers/finance.ts
@@ -22,11 +22,12 @@ export const financeRouter = router({
       const rows = await db
         .select()
         .from(expenses)
-        .where(eq(expenses.householdId, ctx.householdId));
+        .where(
+          input.petId
+            ? and(eq(expenses.householdId, ctx.householdId), eq(expenses.petId, input.petId))
+            : eq(expenses.householdId, ctx.householdId)
+        );
 
-      if (input.petId) {
-        return rows.filter((r) => r.petId === input.petId);
-      }
       return rows;
     }),
 

--- a/apps/api/src/routers/health.ts
+++ b/apps/api/src/routers/health.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq, and, lt, gt, asc, inArray } from "drizzle-orm";
 import { householdProcedure, router } from "../trpc.js";
 import {
   db,
@@ -33,11 +33,12 @@ export const healthRouter = router({
       const rows = await db
         .select()
         .from(healthRecords)
-        .where(eq(healthRecords.householdId, ctx.householdId));
+        .where(
+          input.type
+            ? and(eq(healthRecords.householdId, ctx.householdId), eq(healthRecords.type, input.type))
+            : eq(healthRecords.householdId, ctx.householdId)
+        );
 
-      if (input.type) {
-        return rows.filter((r) => r.type === input.type);
-      }
       return rows;
     }),
 
@@ -112,11 +113,12 @@ export const healthRouter = router({
       const rows = await db
         .select()
         .from(medications)
-        .where(eq(medications.householdId, ctx.householdId));
+        .where(
+          input.activeOnly
+            ? and(eq(medications.householdId, ctx.householdId), eq(medications.isActive, true))
+            : eq(medications.householdId, ctx.householdId)
+        );
 
-      if (input.activeOnly) {
-        return rows.filter((m) => m.isActive);
-      }
       return rows;
     }),
 
@@ -340,8 +342,8 @@ export const healthRouter = router({
   summary: householdProcedure.query(async ({ ctx }) => {
     const now = new Date();
 
-    // Fetch medications, health records, and pets in parallel
-    const [allMeds, allRecords, householdPets] = await Promise.all([
+    // Fetch only the data we need with targeted queries
+    const [allMeds, overdueVaccinations, nextAppointmentRows] = await Promise.all([
       db
         .select()
         .from(medications)
@@ -354,36 +356,41 @@ export const healthRouter = router({
       db
         .select()
         .from(healthRecords)
-        .where(eq(healthRecords.householdId, ctx.householdId)),
-      db.select().from(pets).where(eq(pets.householdId, ctx.householdId)),
+        .where(
+          and(
+            eq(healthRecords.householdId, ctx.householdId),
+            eq(healthRecords.type, "vaccination"),
+            lt(healthRecords.nextDueDate, now)
+          )
+        ),
+      db
+        .select({
+          petId: healthRecords.petId,
+          date: healthRecords.date,
+          reason: healthRecords.reason,
+        })
+        .from(healthRecords)
+        .where(
+          and(
+            eq(healthRecords.householdId, ctx.householdId),
+            inArray(healthRecords.type, ["vet_visit", "checkup", "procedure"]),
+            gt(healthRecords.date, now)
+          )
+        )
+        .orderBy(asc(healthRecords.date))
+        .limit(1),
     ]);
-    const petMap = new Map(householdPets.map((p) => [p.id, p.name]));
-
-    const overdueVaccinations = allRecords.filter(
-      (r) =>
-        r.type === "vaccination" &&
-        r.nextDueDate &&
-        new Date(r.nextDueDate) < now
-    );
-
-    // Next future appointment (vet_visit, checkup, or procedure with date > now)
-    const futureAppointments = allRecords
-      .filter(
-        (r) =>
-          (r.type === "vet_visit" ||
-            r.type === "checkup" ||
-            r.type === "procedure") &&
-          new Date(r.date) > now
-      )
-      .sort(
-        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-      );
 
     let nextAppointment: HealthSummary["nextAppointment"] = null;
-    if (futureAppointments.length > 0) {
-      const appt = futureAppointments[0];
+    if (nextAppointmentRows.length > 0) {
+      const appt = nextAppointmentRows[0];
+      // Fetch pet name only if we have an appointment
+      const [pet] = await db
+        .select({ name: pets.name })
+        .from(pets)
+        .where(eq(pets.id, appt.petId));
       nextAppointment = {
-        petName: petMap.get(appt.petId) ?? "Unknown",
+        petName: pet?.name ?? "Unknown",
         date: appt.date.toISOString(),
         reason: appt.reason,
       };


### PR DESCRIPTION
## Summary
Eliminated N+1 queries and inefficient in-memory filtering patterns across 4 API routers:

- **finance.ts**: Move petId filtering into database WHERE clause instead of JS filter
- **health.ts**: Move type and activeOnly filtering into WHERE clause; refactor summary to use 3 targeted queries instead of full table scan
- **export.ts**: Replace O(n*m) .find() loop with O(1) Map lookup for pet gamification data
- **calendar.ts**: Replace nested loop (days × holidays) with Map-based lookup

## Testing
- Build passes (TypeScript compilation verified)
- No functional changes, only query optimization
- All procedures remain type-safe via tRPC

Generated with Claude Code