### PR TITLE
Validate required env vars on startup (Issue #29)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,10 +55,14 @@ app.use("/*", async (c, next) => {
   );
 });
 
+// In production, NEXT_PUBLIC_WEB_URL is required by the env schema — no
+// silent fallback to localhost. In development it defaults to localhost:3000.
+const corsOrigin = env.NEXT_PUBLIC_WEB_URL ?? "http://localhost:3000";
+
 app.use(
   "/*",
   cors({
-    origin: env.NEXT_PUBLIC_WEB_URL ?? "http://localhost:3000",
+    origin: corsOrigin,
     credentials: true,
   })
 );

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,45 +1,9 @@
-import { z } from "zod";
+import { apiEnvSchema, validateEnv } from "@petforce/core";
 
-const envSchema = z.object({
-  // Database
-  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-  DATABASE_POOL_SIZE: z.coerce.number().int().positive().default(25),
-
-  // Clerk Auth (at least one required)
-  CLERK_SECRET_KEY: z.string().min(1).optional(),
-  CLERK_JWT_KEY: z.string().min(1).optional(),
-
-  // Supabase Storage
-  SUPABASE_URL: z.string().url("SUPABASE_URL must be a valid URL"),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, "SUPABASE_SERVICE_ROLE_KEY is required"),
-
-  // Server
-  PORT: z.coerce.number().int().positive().optional(),
-  API_PORT: z.coerce.number().int().positive().optional(),
-
-  // CORS
-  NEXT_PUBLIC_WEB_URL: z.string().url().optional(),
-
-  // Rate Limiting (optional — falls back to in-memory if not set)
-  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
-  UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
-}).refine(
-  (data) => data.CLERK_SECRET_KEY || data.CLERK_JWT_KEY,
-  { message: "Either CLERK_SECRET_KEY or CLERK_JWT_KEY must be set" }
-);
-
-export type Env = z.infer<typeof envSchema>;
-
-function validateEnv(): Env {
-  const result = envSchema.safeParse(process.env);
-  if (!result.success) {
-    console.error("❌ Invalid environment variables:");
-    for (const issue of result.error.issues) {
-      console.error(`  - ${issue.path.join(".")}: ${issue.message}`);
-    }
-    process.exit(1);
-  }
-  return result.data;
-}
-
-export const env = validateEnv();
+/**
+ * Validated environment variables for the API server.
+ *
+ * This runs at import time — if any required vars are missing or invalid the
+ * process will exit immediately with a clear listing of every problem.
+ */
+export const env = validateEnv(apiEnvSchema);

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,6 +1,7 @@
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import type { Context as HonoContext } from "hono";
+import { env } from "./env.js";
 
 function getClientIp(c: HonoContext): string {
   return (
@@ -29,8 +30,8 @@ type RateLimiterFn = (identifier: string, category: "auth" | "upload" | "standar
 
 function createRedisLimiter(): RateLimiterFn {
   const redis = new Redis({
-    url: process.env.UPSTASH_REDIS_REST_URL!,
-    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+    url: env.UPSTASH_REDIS_REST_URL!,
+    token: env.UPSTASH_REDIS_REST_TOKEN!,
   });
 
   const limiters = {
@@ -101,7 +102,7 @@ function createInMemoryLimiter(): RateLimiterFn {
 }
 
 const rateLimiter: RateLimiterFn =
-  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+  env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
     ? createRedisLimiter()
     : createInMemoryLimiter();
 

--- a/apps/api/src/lib/supabase-storage.ts
+++ b/apps/api/src/lib/supabase-storage.ts
@@ -1,4 +1,5 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { env } from "./env.js";
 
 const BUCKET = "pet-avatars";
 
@@ -6,12 +7,9 @@ let _supabase: SupabaseClient | null = null;
 
 function getSupabase(): SupabaseClient {
   if (!_supabase) {
-    const url = process.env.SUPABASE_URL;
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!url || !key) {
-      throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set for pet avatar uploads");
-    }
-    _supabase = createClient(url, key);
+    // env.SUPABASE_URL and env.SUPABASE_SERVICE_ROLE_KEY are guaranteed to
+    // be present — they are validated at startup by the env schema.
+    _supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
   }
   return _supabase;
 }

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared environment variable schemas
+//
+// These Zod schemas define the environment variables used across the monorepo.
+// Each app/package picks the subset it needs. The API server validates ALL
+// required vars on startup and fails fast with a comprehensive error listing.
+// ---------------------------------------------------------------------------
+
+/** Database-related env vars (used by @petforce/db and @petforce/api). */
+export const dbEnvSchema = z.object({
+  DATABASE_URL: z
+    .string({ required_error: "DATABASE_URL is required" })
+    .min(1, "DATABASE_URL must not be empty")
+    .startsWith("postgres", "DATABASE_URL must be a PostgreSQL connection string"),
+
+  /** Optional — defaults to 20 in production, 5 in development. */
+  DATABASE_POOL_SIZE: z.coerce.number().int().positive().optional(),
+
+  /** Optional — defaults to 30 000 ms. */
+  DB_STATEMENT_TIMEOUT: z.coerce.number().int().positive().optional(),
+});
+
+/** Clerk authentication env vars. */
+export const clerkEnvSchema = z
+  .object({
+    CLERK_SECRET_KEY: z.string().min(1).optional(),
+    CLERK_JWT_KEY: z.string().min(1).optional(),
+  })
+  .refine((data) => data.CLERK_SECRET_KEY || data.CLERK_JWT_KEY, {
+    message:
+      "At least one of CLERK_SECRET_KEY or CLERK_JWT_KEY must be set for authentication",
+  });
+
+/** Supabase storage env vars. */
+export const supabaseEnvSchema = z.object({
+  SUPABASE_URL: z
+    .string({ required_error: "SUPABASE_URL is required" })
+    .url("SUPABASE_URL must be a valid URL"),
+  SUPABASE_SERVICE_ROLE_KEY: z
+    .string({ required_error: "SUPABASE_SERVICE_ROLE_KEY is required" })
+    .min(1, "SUPABASE_SERVICE_ROLE_KEY must not be empty"),
+});
+
+/** Server / networking env vars. */
+export const serverEnvSchema = z.object({
+  /** Optional — defaults to API_PORT or 3001. */
+  PORT: z.coerce.number().int().positive().optional(),
+  /** Optional — defaults to 3001. */
+  API_PORT: z.coerce.number().int().positive().optional(),
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .optional()
+    .default("development"),
+});
+
+/** CORS / frontend URL env vars. */
+export const corsEnvSchema = z.object({
+  /**
+   * Required in production to prevent the CORS origin from silently falling
+   * back to localhost. Optional in development (defaults to http://localhost:3000).
+   */
+  NEXT_PUBLIC_WEB_URL: z.string().url("NEXT_PUBLIC_WEB_URL must be a valid URL").optional(),
+});
+
+/** Rate-limiting env vars (optional — falls back to in-memory limiter). */
+export const rateLimitEnvSchema = z.object({
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Composite schema for the API server (validates everything at once)
+// ---------------------------------------------------------------------------
+
+export const apiEnvSchema = dbEnvSchema
+  .merge(supabaseEnvSchema)
+  .merge(serverEnvSchema)
+  .merge(corsEnvSchema)
+  .merge(rateLimitEnvSchema)
+  // Clerk fields need special handling because of the refine()
+  .extend({
+    CLERK_SECRET_KEY: z.string().min(1).optional(),
+    CLERK_JWT_KEY: z.string().min(1).optional(),
+  })
+  .refine((data) => data.CLERK_SECRET_KEY || data.CLERK_JWT_KEY, {
+    message:
+      "At least one of CLERK_SECRET_KEY or CLERK_JWT_KEY must be set for authentication",
+  })
+  .refine(
+    (data) => {
+      // In production, NEXT_PUBLIC_WEB_URL must be explicitly set
+      if (data.NODE_ENV === "production" && !data.NEXT_PUBLIC_WEB_URL) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        "NEXT_PUBLIC_WEB_URL is required in production to configure CORS (do not rely on the localhost fallback)",
+    }
+  );
+
+export type ApiEnv = z.infer<typeof apiEnvSchema>;
+export type DbEnv = z.infer<typeof dbEnvSchema>;
+
+// ---------------------------------------------------------------------------
+// Validation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate env vars against a Zod schema. On failure, prints every
+ * validation error (not just the first) and terminates the process.
+ */
+export function validateEnv<T>(
+  schema: z.ZodType<T>,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>
+): T {
+  const result = schema.safeParse(env);
+  if (!result.success) {
+    const header = "Environment variable validation failed:";
+    const details = result.error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+        return `  - ${path}: ${issue.message}`;
+      })
+      .join("\n");
+    const message = `\n${header}\n${details}\n`;
+
+    // Use stderr so it shows up even if stdout is piped
+    console.error(message);
+    process.exit(1);
+  }
+  return result.data;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from "./schemas.js";
 export * from "./constants.js";
 export * from "./gamification-levels.js";
 export * from "./gamification-badges.js";
+export * from "./env.js";

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,22 +1,20 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { dbEnvSchema, validateEnv } from "@petforce/core";
 import * as schema from "./schema.js";
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  throw new Error("DATABASE_URL environment variable is required");
-}
+const dbEnv = validateEnv(dbEnvSchema);
 
 const isProduction = process.env.NODE_ENV === "production";
 
-const client = postgres(connectionString, {
-  max: parseInt(process.env.DATABASE_POOL_SIZE || (isProduction ? "20" : "5")),
+const client = postgres(dbEnv.DATABASE_URL, {
+  max: dbEnv.DATABASE_POOL_SIZE ?? (isProduction ? 20 : 5),
   idle_timeout: 20,
   connect_timeout: 10,
   max_lifetime: 60 * 30,
   connection: {
     application_name: "petforce-api",
-    statement_timeout: parseInt(process.env.DB_STATEMENT_TIMEOUT || "30000"),
+    statement_timeout: dbEnv.DB_STATEMENT_TIMEOUT ?? 30000,
   },
   onnotice: () => {},
 });

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2,15 +2,12 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { dbEnvSchema, validateEnv } from "@petforce/core";
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  console.error("DATABASE_URL is required");
-  process.exit(1);
-}
+const dbEnv = validateEnv(dbEnvSchema);
 
 // Use max 1 connection for migrations
-const client = postgres(connectionString, { max: 1 });
+const client = postgres(dbEnv.DATABASE_URL, { max: 1 });
 const db = drizzle(client);
 
 async function main() {


### PR DESCRIPTION
Add Zod-based validation for required environment variables at API server startup.

- Shared env schemas in `@petforce/core` for reuse across packages
- Server fails fast with all validation errors listed at once
- CORS origin required in production (prevents localhost:3000 fallback)
- Database pool and statement timeout now validated with sensible defaults

Closes #29