### PR TITLE
Add text field length constraints (Issue #38)

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -68,7 +68,7 @@ export const createPetSchema = z.object({
   adoptionDate: z.coerce.date().nullable().optional(),
   microchipNumber: z.string().max(50).nullable().optional(),
   rabiesTagNumber: z.string().max(50).nullable().optional(),
-  medicalNotes: z.string().max(5000).nullable().optional(),
+  medicalNotes: z.string().max(10_240).nullable().optional(),
 });
 
 export const updatePetSchema = createPetSchema.partial();
@@ -248,14 +248,14 @@ export const financeSummaryInputSchema = z.object({
 export const createNoteSchema = z.object({
   petId: z.string().uuid().nullable().optional(),
   title: z.string().min(1).max(100),
-  content: z.string().min(1).max(5000),
+  content: z.string().min(1).max(51_200),
 });
 
 export const updateNoteSchema = z.object({
   id: z.string().uuid(),
   petId: z.string().uuid().nullable().optional(),
   title: z.string().min(1).max(100).optional(),
-  content: z.string().min(1).max(5000).optional(),
+  content: z.string().min(1).max(51_200).optional(),
 });
 
 // --- Reporting ---
@@ -283,10 +283,19 @@ export const reportingTrendsSchema = z.object({
 
 // --- Analytics ---
 
+// Max serialized size for JSONB metadata fields (10 KB)
+const MAX_METADATA_JSON_LENGTH = 10_240;
+
 export const trackEventSchema = z.object({
   eventName: z.string().min(1).max(100),
   householdId: z.string().uuid().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z
+    .record(z.unknown())
+    .refine(
+      (val) => JSON.stringify(val).length <= MAX_METADATA_JSON_LENGTH,
+      { message: `Metadata must be under ${MAX_METADATA_JSON_LENGTH} characters when serialized` },
+    )
+    .optional(),
 });
 
 // --- Pet Photos ---

--- a/packages/db/drizzle/0004_add_text_length_constraints.sql
+++ b/packages/db/drizzle/0004_add_text_length_constraints.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "pets" ADD CONSTRAINT "pets_medical_notes_length" CHECK (length("medical_notes") <= 10240);--> statement-breakpoint
+ALTER TABLE "pet_notes" ADD CONSTRAINT "pet_notes_content_length" CHECK (length("content") <= 51200);--> statement-breakpoint
+ALTER TABLE "activity_log" ADD CONSTRAINT "activity_log_metadata_length" CHECK (length("metadata"::text) <= 10240);--> statement-breakpoint
+ALTER TABLE "analytics_events" ADD CONSTRAINT "analytics_events_metadata_length" CHECK (length("metadata"::text) <= 10240);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773357327550,
       "tag": "0003_ordinary_wildside",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1773440000000,
+      "tag": "0004_add_text_length_constraints",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -10,7 +10,9 @@ import {
   integer,
   index,
   uniqueIndex,
+  check,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 // --- Households ---
 
@@ -68,6 +70,7 @@ export const pets = pgTable("pets", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({
   householdIdx: index("pets_household_idx").on(table.householdId),
+  medicalNotesLength: check("pets_medical_notes_length", sql`length(${table.medicalNotes}) <= 10240`),
 }));
 
 // --- Pet Photos ---
@@ -374,6 +377,7 @@ export const petNotes = pgTable("pet_notes", {
 }, (table) => ({
   householdIdx: index("pet_notes_household_idx").on(table.householdId),
   petIdx: index("pet_notes_pet_idx").on(table.petId),
+  contentLength: check("pet_notes_content_length", sql`length(${table.content}) <= 51200`),
 }));
 
 // --- Access Requests ---
@@ -494,6 +498,7 @@ export const activityLog = pgTable("activity_log", {
     table.performedBy,
     table.createdAt
   ),
+  metadataLength: check("activity_log_metadata_length", sql`length(${table.metadata}::text) <= 10240`),
 }));
 
 // --- Analytics Events ---
@@ -510,4 +515,5 @@ export const analyticsEvents = pgTable("analytics_events", {
 }, (table) => ({
   userCreatedIdx: index("analytics_events_user_created_idx").on(table.userId, table.createdAt),
   householdCreatedIdx: index("analytics_events_household_created_idx").on(table.householdId, table.createdAt),
+  metadataLength: check("analytics_events_metadata_length", sql`length(${table.metadata}::text) <= 10240`),
 }));


### PR DESCRIPTION
Add Zod validation limits and database CHECK constraints for TEXT columns.

- Notes content: 50KB, medical notes: 10KB, metadata: 10KB
- Zod validation in schemas.ts, CHECK constraints in Drizzle schema
- Migration included: 0004_add_text_length_constraints.sql

Closes #38