### PR TITLE
Fix deploy API failure by building core before migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build core package
+        run: pnpm build --filter=@petforce/core
+
       # Run database migrations before deploying new code
       - name: Run database migrations
         run: pnpm --filter=@petforce/db db:migrate


### PR DESCRIPTION
## Summary
Adds `pnpm build --filter=@petforce/core` before running database migrations in the deploy workflow. The migration script imports from @petforce/core, which points to compiled output (dist/index.js), so the build step is required.

## Type of change
- [x] Bug fix

## Closes
<!-- Link related issues if any -->

## Breaking changes
None

## Documentation
Internal CI/CD fix, no user-facing changes.

## Test plan
Deploy workflow should now successfully build core and run migrations without "Cannot find package" errors.

## Size check
3 lines added. Minimal change.