### PR TITLE
Add pagination to all list endpoints

### DIFF
--- a/apps/api/src/routers/access-request.ts
+++ b/apps/api/src/routers/access-request.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { householdProcedure, protectedProcedure, router, requireAdmin } from "../trpc.js";
 import { db, accessRequests, members, households } from "@petforce/db";
@@ -78,18 +78,21 @@ export const accessRequestRouter = router({
     .query(async ({ ctx, input }) => {
       requireAdmin(ctx.membership);
 
-      return db
-        .select()
-        .from(accessRequests)
-        .where(
-          and(
-            eq(accessRequests.householdId, ctx.householdId),
-            eq(accessRequests.status, "pending")
-          )
-        )
-        .orderBy(desc(accessRequests.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = and(
+        eq(accessRequests.householdId, ctx.householdId),
+        eq(accessRequests.status, "pending")
+      );
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(accessRequests)
+          .where(where)
+          .orderBy(desc(accessRequests.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(accessRequests).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   approve: householdProcedure

--- a/apps/api/src/routers/activity.ts
+++ b/apps/api/src/routers/activity.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { protectedProcedure, householdProcedure, router, verifyMembership } from "../trpc.js";
 import { db, activities, pets } from "@petforce/db";
@@ -9,17 +9,22 @@ export const activityRouter = router({
   listByHousehold: householdProcedure
     .input(paginationInput)
     .query(async ({ ctx, input }) => {
-      return db
-        .select()
-        .from(activities)
-        .where(eq(activities.householdId, ctx.householdId))
-        .orderBy(desc(activities.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = eq(activities.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(activities)
+          .where(where)
+          .orderBy(desc(activities.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(activities).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   listByPet: householdProcedure
-    .input(z.object({ petId: z.string().uuid() }))
+    .input(z.object({ petId: z.string().uuid() }).merge(paginationInput))
     .query(async ({ ctx, input }) => {
       // Verify the pet belongs to the claimed household
       const [pet] = await db
@@ -33,15 +38,21 @@ export const activityRouter = router({
         });
       }
 
-      return db
-        .select()
-        .from(activities)
-        .where(
-          and(
-            eq(activities.petId, input.petId),
-            eq(activities.householdId, ctx.householdId)
-          )
-        );
+      const where = and(
+        eq(activities.petId, input.petId),
+        eq(activities.householdId, ctx.householdId)
+      );
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(activities)
+          .where(where)
+          .orderBy(desc(activities.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(activities).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   create: householdProcedure

--- a/apps/api/src/routers/feeding.ts
+++ b/apps/api/src/routers/feeding.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { householdProcedure, router } from "../trpc.js";
 import {
@@ -27,18 +27,21 @@ export const feedingRouter = router({
   listSchedules: householdProcedure
     .input(paginationInput)
     .query(async ({ ctx, input }) => {
-      return db
-        .select()
-        .from(feedingSchedules)
-        .where(
-          and(
-            eq(feedingSchedules.householdId, ctx.householdId),
-            eq(feedingSchedules.isActive, true)
-          )
-        )
-        .orderBy(desc(feedingSchedules.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = and(
+        eq(feedingSchedules.householdId, ctx.householdId),
+        eq(feedingSchedules.isActive, true)
+      );
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(feedingSchedules)
+          .where(where)
+          .orderBy(desc(feedingSchedules.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(feedingSchedules).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   createSchedule: householdProcedure

--- a/apps/api/src/routers/finance.ts
+++ b/apps/api/src/routers/finance.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, gte, lt, gt, isNotNull, desc } from "drizzle-orm";
+import { eq, and, gte, lt, gt, isNotNull, desc, count as drizzleCount } from "drizzle-orm";
 import { householdProcedure, router } from "../trpc.js";
 import {
   db,
@@ -20,19 +20,20 @@ export const financeRouter = router({
   listExpenses: householdProcedure
     .input(z.object({ petId: z.string().uuid().optional() }).merge(paginationInput))
     .query(async ({ ctx, input }) => {
-      const rows = await db
-        .select()
-        .from(expenses)
-        .where(
-          input.petId
-            ? and(eq(expenses.householdId, ctx.householdId), eq(expenses.petId, input.petId))
-            : eq(expenses.householdId, ctx.householdId)
-        )
-        .orderBy(desc(expenses.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
-
-      return rows;
+      const where = input.petId
+        ? and(eq(expenses.householdId, ctx.householdId), eq(expenses.petId, input.petId))
+        : eq(expenses.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(expenses)
+          .where(where)
+          .orderBy(desc(expenses.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(expenses).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   createExpense: householdProcedure

--- a/apps/api/src/routers/health.ts
+++ b/apps/api/src/routers/health.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, lt, gt, asc, desc, inArray } from "drizzle-orm";
+import { eq, and, lt, gt, asc, desc, inArray, count as drizzleCount } from "drizzle-orm";
 import { householdProcedure, router } from "../trpc.js";
 import {
   db,
@@ -31,19 +31,20 @@ export const healthRouter = router({
       }).merge(paginationInput)
     )
     .query(async ({ ctx, input }) => {
-      const rows = await db
-        .select()
-        .from(healthRecords)
-        .where(
-          input.type
-            ? and(eq(healthRecords.householdId, ctx.householdId), eq(healthRecords.type, input.type))
-            : eq(healthRecords.householdId, ctx.householdId)
-        )
-        .orderBy(desc(healthRecords.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
-
-      return rows;
+      const where = input.type
+        ? and(eq(healthRecords.householdId, ctx.householdId), eq(healthRecords.type, input.type))
+        : eq(healthRecords.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(healthRecords)
+          .where(where)
+          .orderBy(desc(healthRecords.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(healthRecords).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   createRecord: householdProcedure
@@ -114,19 +115,20 @@ export const healthRouter = router({
   listMedications: householdProcedure
     .input(z.object({ activeOnly: z.boolean().optional() }).merge(paginationInput))
     .query(async ({ ctx, input }) => {
-      const rows = await db
-        .select()
-        .from(medications)
-        .where(
-          input.activeOnly
-            ? and(eq(medications.householdId, ctx.householdId), eq(medications.isActive, true))
-            : eq(medications.householdId, ctx.householdId)
-        )
-        .orderBy(desc(medications.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
-
-      return rows;
+      const where = input.activeOnly
+        ? and(eq(medications.householdId, ctx.householdId), eq(medications.isActive, true))
+        : eq(medications.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(medications)
+          .where(where)
+          .orderBy(desc(medications.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(medications).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   createMedication: householdProcedure

--- a/apps/api/src/routers/invitation.ts
+++ b/apps/api/src/routers/invitation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { householdProcedure, protectedProcedure, router, requireAdmin } from "../trpc.js";
 import { db, invitations, members, households } from "@petforce/db";
@@ -37,13 +37,18 @@ export const invitationRouter = router({
     .query(async ({ ctx, input }) => {
       requireAdmin(ctx.membership);
 
-      return db
-        .select()
-        .from(invitations)
-        .where(eq(invitations.householdId, ctx.householdId))
-        .orderBy(desc(invitations.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = eq(invitations.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(invitations)
+          .where(where)
+          .orderBy(desc(invitations.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(invitations).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   revoke: householdProcedure

--- a/apps/api/src/routers/member.ts
+++ b/apps/api/src/routers/member.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { householdProcedure, router, requireAdmin } from "../trpc.js";
 import { db, members } from "@petforce/db";
@@ -10,13 +10,18 @@ export const memberRouter = router({
   listByHousehold: householdProcedure
     .input(paginationInput)
     .query(async ({ ctx, input }) => {
-      return db
-        .select()
-        .from(members)
-        .where(eq(members.householdId, ctx.householdId))
-        .orderBy(desc(members.joinedAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = eq(members.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(members)
+          .where(where)
+          .orderBy(desc(members.joinedAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(members).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   invite: householdProcedure

--- a/apps/api/src/routers/notes.ts
+++ b/apps/api/src/routers/notes.ts
@@ -1,31 +1,36 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, isNull, count as drizzleCount } from "drizzle-orm";
 import { householdProcedure, router } from "../trpc.js";
 import { db, petNotes, pets } from "@petforce/db";
-import { createNoteSchema, updateNoteSchema } from "@petforce/core";
+import { createNoteSchema, updateNoteSchema, paginationInput } from "@petforce/core";
 
 export const notesRouter = router({
   list: householdProcedure
     .input(
       z.object({
         petId: z.string().uuid().nullable().optional(),
-      })
+      }).merge(paginationInput)
     )
     .query(async ({ ctx, input }) => {
-      const rows = await db
-        .select()
-        .from(petNotes)
-        .where(eq(petNotes.householdId, ctx.householdId))
-        .orderBy(desc(petNotes.updatedAt));
-
+      const conditions = [eq(petNotes.householdId, ctx.householdId)];
       if (input.petId === null) {
-        // Household-only notes
-        return rows.filter((r) => r.petId === null);
+        conditions.push(isNull(petNotes.petId));
+      } else if (input.petId) {
+        conditions.push(eq(petNotes.petId, input.petId));
       }
-      if (input.petId) {
-        return rows.filter((r) => r.petId === input.petId);
-      }
-      return rows;
+      const where = and(...conditions);
+
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(petNotes)
+          .where(where)
+          .orderBy(desc(petNotes.updatedAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(petNotes).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   recent: householdProcedure.query(async ({ ctx }) => {

--- a/apps/api/src/routers/pet.ts
+++ b/apps/api/src/routers/pet.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, count as drizzleCount } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { protectedProcedure, householdProcedure, router, verifyMembership, requireAdmin } from "../trpc.js";
 import { db, pets } from "@petforce/db";
@@ -9,13 +9,18 @@ export const petRouter = router({
   listByHousehold: householdProcedure
     .input(paginationInput)
     .query(async ({ ctx, input }) => {
-      return db
-        .select()
-        .from(pets)
-        .where(eq(pets.householdId, ctx.householdId))
-        .orderBy(desc(pets.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = eq(pets.householdId, ctx.householdId);
+      const [items, [{ count }]] = await Promise.all([
+        db
+          .select()
+          .from(pets)
+          .where(where)
+          .orderBy(desc(pets.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.select({ count: drizzleCount() }).from(pets).where(where),
+      ]);
+      return { items, totalCount: count };
     }),
 
   getById: protectedProcedure

--- a/apps/web/src/app/dashboard/log-activity/page.tsx
+++ b/apps/web/src/app/dashboard/log-activity/page.tsx
@@ -69,7 +69,7 @@ export default function LogActivityPage() {
     return <p style={{ padding: "2rem", color: "var(--pf-text-muted)" }}>No household selected.</p>;
   }
 
-  const pets = petsQuery.data ?? [];
+  const pets = petsQuery.data?.items ?? [];
 
   return (
     <main style={{ maxWidth: 480, margin: "0 auto", padding: "3rem 1.5rem", fontFamily: "system-ui, sans-serif" }}>

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -193,11 +193,11 @@ function MembersTab({
       </div>
 
       {/* Pending Access Requests */}
-      {isAdmin && accessRequestsQuery.data && accessRequestsQuery.data.length > 0 && (
+      {isAdmin && accessRequestsQuery.data?.items && accessRequestsQuery.data.items.length > 0 && (
         <div style={glassCard}>
           <h2 style={sectionTitle}>Pending Requests</h2>
           <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            {accessRequestsQuery.data.map((req) => (
+            {accessRequestsQuery.data.items.map((req) => (
               <div key={req.id} style={memberRow}>
                 <div style={{ ...initialsCircle, background: "linear-gradient(135deg, #F59E0B, #FBBF24)" }}>
                   {req.displayName.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase()}
@@ -265,8 +265,8 @@ function InvitesTab({ householdId, isAdmin }: { householdId: string; isAdmin: bo
     );
   }
 
-  const pendingInvites = (invitesQuery.data ?? []).filter((i) => i.status === "pending");
-  const pastInvites = (invitesQuery.data ?? []).filter((i) => i.status !== "pending");
+  const pendingInvites = (invitesQuery.data?.items ?? []).filter((i) => i.status === "pending");
+  const pastInvites = (invitesQuery.data?.items ?? []).filter((i) => i.status !== "pending");
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>

--- a/apps/web/src/components/feeding-manage-modal.tsx
+++ b/apps/web/src/components/feeding-manage-modal.tsx
@@ -61,7 +61,7 @@ export function FeedingManageModal({ householdId, onClose }: FeedingManageModalP
   });
 
   const pets = dashboardQuery.data?.pets ?? [];
-  const schedules = schedulesQuery.data ?? [];
+  const schedules = schedulesQuery.data?.items ?? [];
 
   // Auto-select first pet if only one
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");

--- a/apps/web/src/components/finance-modal.tsx
+++ b/apps/web/src/components/finance-modal.tsx
@@ -215,7 +215,7 @@ function ExpensesTab({ householdId }: { householdId: string }) {
   const pets = dashboardQuery.data?.pets ?? [];
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");
 
-  const allExpenses = expensesQuery.data ?? [];
+  const allExpenses = expensesQuery.data?.items ?? [];
 
   // Description suggestion chips
   const suggestions = EXPENSE_DESCRIPTION_SUGGESTIONS[category] ?? [];

--- a/apps/web/src/components/health-modal.tsx
+++ b/apps/web/src/components/health-modal.tsx
@@ -107,7 +107,7 @@ function VetVisitsTab({ householdId }: { householdId: string }) {
   const pets = dashboardQuery.data?.pets ?? [];
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");
 
-  const records = (recordsQuery.data ?? []).filter(
+  const records = (recordsQuery.data?.items ?? []).filter(
     (r) => r.type === "vet_visit" || r.type === "checkup" || r.type === "procedure"
   );
 
@@ -314,7 +314,7 @@ function VaccinationsTab({ householdId }: { householdId: string }) {
   const pets = dashboardQuery.data?.pets ?? [];
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");
 
-  const records = (recordsQuery.data ?? []).filter((r) => r.type === "vaccination");
+  const records = (recordsQuery.data?.items ?? []).filter((r) => r.type === "vaccination");
 
   // Determine species for suggestions
   const selectedPet = pets.find((p) => p.id === effectivePetId);
@@ -529,7 +529,7 @@ function MedicationsTab({ householdId }: { householdId: string }) {
 
   const pets = dashboardQuery.data?.pets ?? [];
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");
-  const meds = medsQuery.data ?? [];
+  const meds = medsQuery.data?.items ?? [];
 
   function resetForm() {
     setName("");

--- a/apps/web/src/components/notes-modal.tsx
+++ b/apps/web/src/components/notes-modal.tsx
@@ -48,7 +48,7 @@ export function NotesModal({ householdId, onClose }: NotesModalProps) {
   });
 
   const pets = dashboardQuery.data?.pets ?? [];
-  const allNotes = notesQuery.data ?? [];
+  const allNotes = notesQuery.data?.items ?? [];
   const petMap = new Map(pets.map((p) => [p.id, p.name]));
 
   // Client-side filter

--- a/packages/core/src/pagination.ts
+++ b/packages/core/src/pagination.ts
@@ -9,3 +9,11 @@ export const paginationInput = z.object({
   limit: z.number().int().min(1).max(500).default(50),
   offset: z.number().int().min(0).default(0),
 });
+
+/**
+ * Standard paginated response shape returned by all list endpoints.
+ */
+export interface PaginatedResponse<T> {
+  items: T[];
+  totalCount: number;
+}

--- a/tests/e2e/access-request.test.ts
+++ b/tests/e2e/access-request.test.ts
@@ -42,7 +42,7 @@ test.describe("Access Request Admin + Error Paths", () => {
       { householdId }
     );
 
-    expect(Array.isArray(result)).toBe(true);
+    expect(Array.isArray(result.items)).toBe(true);
   });
 
   test("approve with nonexistent ID returns NOT_FOUND", async ({

--- a/tests/e2e/activity.test.ts
+++ b/tests/e2e/activity.test.ts
@@ -41,8 +41,8 @@ test.describe("Activity CRUD", () => {
     const pets = await trpcQuery(request, authToken, "pet.listByHousehold", {
       householdId,
     });
-    if (Array.isArray(pets) && pets.length > 0) {
-      testPetId = pets[0].id;
+    if (pets.items && pets.items.length > 0) {
+      testPetId = pets.items[0].id;
     }
   });
 
@@ -94,7 +94,7 @@ test.describe("Activity CRUD", () => {
       { householdId }
     );
 
-    expect(Array.isArray(activities)).toBe(true);
+    expect(Array.isArray(activities.items)).toBe(true);
   });
 
   test("lists activities by pet", async ({ request }) => {
@@ -107,8 +107,8 @@ test.describe("Activity CRUD", () => {
       { householdId, petId: testPetId }
     );
 
-    expect(Array.isArray(activities)).toBe(true);
-    for (const a of activities) {
+    expect(Array.isArray(activities.items)).toBe(true);
+    for (const a of activities.items) {
       expect(a.petId).toBe(testPetId);
     }
   });
@@ -199,7 +199,7 @@ test.describe("Activity CRUD", () => {
       "activity.listByHousehold",
       { householdId }
     );
-    const found = activities.find((a: { id: string }) => a.id === activity.id);
+    const found = activities.items.find((a: { id: string }) => a.id === activity.id);
     expect(found).toBeUndefined();
   });
 });

--- a/tests/e2e/feeding-advanced.test.ts
+++ b/tests/e2e/feeding-advanced.test.ts
@@ -39,8 +39,8 @@ test.describe("Feeding Advanced Operations", () => {
     const pets = await trpcQuery(request, authToken, "pet.listByHousehold", {
       householdId,
     });
-    if (Array.isArray(pets) && pets.length > 0) {
-      testPetId = pets[0].id;
+    if (pets.items && pets.items.length > 0) {
+      testPetId = pets.items[0].id;
     }
   });
 
@@ -221,7 +221,7 @@ test.describe("Feeding Advanced Operations", () => {
       "feeding.listSchedules",
       { householdId }
     );
-    const found = schedules.find((s: { id: string }) => s.id === scheduleId);
+    const found = schedules.items.find((s: { id: string }) => s.id === scheduleId);
     expect(found).toBeUndefined();
 
     scheduleId = ""; // Prevent afterAll from trying to delete again

--- a/tests/e2e/finance-crud.test.ts
+++ b/tests/e2e/finance-crud.test.ts
@@ -37,8 +37,8 @@ test.describe("Finance CRUD & Summary", () => {
     const pets = await trpcQuery(request, authToken, "pet.listByHousehold", {
       householdId,
     });
-    if (Array.isArray(pets) && pets.length > 0) {
-      testPetId = pets[0].id;
+    if (pets.items && pets.items.length > 0) {
+      testPetId = pets.items[0].id;
     }
   });
 
@@ -95,7 +95,7 @@ test.describe("Finance CRUD & Summary", () => {
       "finance.listExpenses",
       { householdId }
     );
-    const found = expenses.find((e: { id: string }) => e.id === expense.id);
+    const found = expenses.items.find((e: { id: string }) => e.id === expense.id);
     expect(found).toBeUndefined();
   });
 
@@ -109,8 +109,8 @@ test.describe("Finance CRUD & Summary", () => {
       { householdId, petId: testPetId }
     );
 
-    expect(Array.isArray(expenses)).toBe(true);
-    for (const e of expenses) {
+    expect(Array.isArray(expenses.items)).toBe(true);
+    for (const e of expenses.items) {
       expect(e.petId).toBe(testPetId);
     }
   });

--- a/tests/e2e/health-advanced.test.ts
+++ b/tests/e2e/health-advanced.test.ts
@@ -37,8 +37,8 @@ test.describe("Health Advanced Operations", () => {
     const pets = await trpcQuery(request, authToken, "pet.listByHousehold", {
       householdId,
     });
-    if (Array.isArray(pets) && pets.length > 0) {
-      testPetId = pets[0].id;
+    if (pets.items && pets.items.length > 0) {
+      testPetId = pets.items[0].id;
     }
   });
 
@@ -98,7 +98,7 @@ test.describe("Health Advanced Operations", () => {
       "health.listRecords",
       { householdId }
     );
-    const found = records.find((r: { id: string }) => r.id === record.id);
+    const found = records.items.find((r: { id: string }) => r.id === record.id);
     expect(found).toBeUndefined();
   });
 
@@ -110,8 +110,8 @@ test.describe("Health Advanced Operations", () => {
       { householdId, type: "vaccination" }
     );
 
-    expect(Array.isArray(records)).toBe(true);
-    for (const r of records) {
+    expect(Array.isArray(records.items)).toBe(true);
+    for (const r of records.items) {
       expect(r.type).toBe("vaccination");
     }
   });
@@ -184,7 +184,7 @@ test.describe("Health Advanced Operations", () => {
       { householdId, activeOnly: true }
     );
 
-    expect(Array.isArray(meds)).toBe(true);
+    expect(Array.isArray(meds.items)).toBe(true);
   });
 
   // --- Medication Daily Status ---

--- a/tests/e2e/household-manage.test.ts
+++ b/tests/e2e/household-manage.test.ts
@@ -112,11 +112,11 @@ test.describe("Household Management", () => {
       { householdId }
     );
 
-    expect(Array.isArray(members)).toBe(true);
-    expect(members.length).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(members.items)).toBe(true);
+    expect(members.items.length).toBeGreaterThanOrEqual(1);
 
     // Current user should be in the list as owner
-    const owner = members.find(
+    const owner = members.items.find(
       (m: { role: string }) => m.role === "owner"
     );
     expect(owner).toBeDefined();

--- a/tests/e2e/invite-admin.test.ts
+++ b/tests/e2e/invite-admin.test.ts
@@ -100,8 +100,8 @@ test.describe("Invitation Lifecycle (Admin)", () => {
       { householdId }
     );
 
-    expect(Array.isArray(invites)).toBe(true);
-    const found = invites.find(
+    expect(Array.isArray(invites.items)).toBe(true);
+    const found = invites.items.find(
       (i: { id: string }) => i.id === created.id
     );
     expect(found).toBeDefined();
@@ -220,8 +220,8 @@ test.describe("Invitation Lifecycle (Admin)", () => {
           "invitation.listByHousehold",
           { householdId }
         );
-        if (Array.isArray(invites)) {
-          const thisInvite = invites.find(
+        if (invites.items && Array.isArray(invites.items)) {
+          const thisInvite = invites.items.find(
             (i: { token: string }) => i.token === tokenMatch[1]
           );
           if (thisInvite) {

--- a/tests/e2e/member.test.ts
+++ b/tests/e2e/member.test.ts
@@ -42,11 +42,11 @@ test.describe("Member Router", () => {
       { householdId }
     );
 
-    expect(Array.isArray(members)).toBe(true);
-    expect(members.length).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(members.items)).toBe(true);
+    expect(members.items.length).toBeGreaterThanOrEqual(1);
 
     // Every member should have required fields
-    for (const m of members) {
+    for (const m of members.items) {
       expect(m.id).toBeDefined();
       expect(m.householdId).toBe(householdId);
       expect(m.userId).toBeDefined();

--- a/tests/e2e/notes.test.ts
+++ b/tests/e2e/notes.test.ts
@@ -71,12 +71,12 @@ test.describe("Notes CRUD", () => {
       householdId,
     });
 
-    if (!Array.isArray(pets) || pets.length === 0) {
+    if (!pets.items || pets.items.length === 0) {
       test.skip();
       return;
     }
 
-    const petId = pets[0].id;
+    const petId = pets.items[0].id;
     const note = await trpcMutation(request, authToken, "notes.create", {
       householdId,
       petId,
@@ -94,9 +94,9 @@ test.describe("Notes CRUD", () => {
       householdId,
     });
 
-    expect(Array.isArray(notes)).toBe(true);
+    expect(Array.isArray(notes.items)).toBe(true);
     // Should contain at least the notes we just created
-    const ourNotes = notes.filter((n: { title: string }) =>
+    const ourNotes = notes.items.filter((n: { title: string }) =>
       n.title.includes("E2E Note") || n.title.includes("Pet Note")
     );
     expect(ourNotes.length).toBeGreaterThanOrEqual(1);
@@ -108,8 +108,8 @@ test.describe("Notes CRUD", () => {
       petId: null,
     });
 
-    expect(Array.isArray(notes)).toBe(true);
-    for (const note of notes) {
+    expect(Array.isArray(notes.items)).toBe(true);
+    for (const note of notes.items) {
       expect(note.petId).toBeNull();
     }
   });
@@ -162,7 +162,7 @@ test.describe("Notes CRUD", () => {
     const notes = await trpcQuery(request, authToken, "notes.list", {
       householdId,
     });
-    const found = notes.find((n: { id: string }) => n.id === note.id);
+    const found = notes.items.find((n: { id: string }) => n.id === note.id);
     expect(found).toBeUndefined();
   });
 });

--- a/tests/e2e/pet-crud.test.ts
+++ b/tests/e2e/pet-crud.test.ts
@@ -77,7 +77,7 @@ test.describe("Pet Update & Delete", () => {
     const pets = await trpcQuery(request, authToken, "pet.listByHousehold", {
       householdId,
     });
-    const found = pets.find((p: { id: string }) => p.id === pet.id);
+    const found = pets.items.find((p: { id: string }) => p.id === pet.id);
     expect(found).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- All 10 list endpoints now return `{ items: T[], totalCount: number }` instead of bare arrays, enabling proper pagination UI controls
- Added parallel `COUNT(*)` queries using Drizzle's `count()` for efficient total counts without loading all rows
- Added pagination (`limit`/`offset`) to `activity.listByPet` and `notes.list` which previously had none
- Fixed `notes.list` to filter at the database level (using `isNull`/`eq`) instead of loading all rows and filtering in memory
- Updated all web frontend consumers and E2E tests to use the new `.items` response shape
- Exported `PaginatedResponse<T>` type from `@petforce/core` for consumers

### Affected routers (10 endpoints)
`activity.listByHousehold`, `activity.listByPet`, `pet.listByHousehold`, `member.listByHousehold`, `health.listRecords`, `health.listMedications`, `finance.listExpenses`, `feeding.listSchedules`, `invitation.listByHousehold`, `accessRequest.listByHousehold`, `notes.list`

## Type of change
- [x] Enhancement (non-breaking change that improves existing functionality)

## Breaking changes
- **Response shape change**: All list endpoints return `{ items, totalCount }` instead of a bare array. Affects `@petforce/web`, `@petforce/mobile` (if consuming these endpoints), and all E2E tests.

## Documentation
- `PaginatedResponse<T>` type is self-documenting via JSDoc in `packages/core/src/pagination.ts`

## Test plan
- [x] All 10 E2E test files updated to use `.items` property
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [ ] E2E tests pass against live API

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)