### PR TITLE
feat: add /paperclip skill — Paperclip-GitHub bridge

### DIFF
--- a/.claude/skills/gstack/bin/gstack-paperclip
+++ b/.claude/skills/gstack/bin/gstack-paperclip
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# gstack-paperclip — query Paperclip for the current agent's active task
+# Usage: eval "$(gstack-paperclip)"  → sets PAPERCLIP_* variables
+# Or:    gstack-paperclip            → prints PAPERCLIP_*=... lines
+#
+# Reads ~/.paperclip/context.json for API base and company ID.
+# Matches current branch/workspace against Paperclip issues.
+# Outputs shell-eval-safe variables (sanitized to prevent injection).
+#
+# Exit 0 always — never blocks the caller. Empty vars if no match.
+set -euo pipefail
+
+emit_empty() {
+  echo 'PAPERCLIP_ISSUE_ID=""'
+  echo 'PAPERCLIP_ISSUE_TITLE=""'
+  echo 'PAPERCLIP_ISSUE_STATUS=""'
+  echo 'PAPERCLIP_ISSUE_PRIORITY=""'
+  echo 'PAPERCLIP_ISSUE_DESCRIPTION=""'
+  echo "PAPERCLIP_COMPANY_ID=\"${COMPANY_ID:-}\""
+  echo "PAPERCLIP_API_BASE=\"${API_BASE:-}\""
+}
+
+# --- Load Paperclip config ---
+CONTEXT_FILE="$HOME/.paperclip/context.json"
+if [ ! -f "$CONTEXT_FILE" ]; then
+  emit_empty
+  exit 0
+fi
+
+API_BASE=$(python3 -c "import json; c=json.load(open('$CONTEXT_FILE')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('apiBase',''))" 2>/dev/null || true)
+COMPANY_ID=$(python3 -c "import json; c=json.load(open('$CONTEXT_FILE')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('companyId',''))" 2>/dev/null || true)
+
+if [ -z "$API_BASE" ] || [ -z "$COMPANY_ID" ]; then
+  emit_empty
+  exit 0
+fi
+
+# --- Fetch issues to a temp file (avoids shell quoting issues with JSON) ---
+TMPFILE=$(mktemp /tmp/gstack-paperclip.XXXXXX)
+trap 'rm -f "$TMPFILE"' EXIT
+
+curl -sf "$API_BASE/api/companies/$COMPANY_ID/issues?limit=100" > "$TMPFILE" 2>/dev/null || echo "[]" > "$TMPFILE"
+
+# --- Determine current branch ---
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Match and output via a single python script ---
+AGENT_ID="${PAPERCLIP_AGENT_ID:-}"
+
+python3 - "$TMPFILE" "$RAW_BRANCH" "$AGENT_ID" "$COMPANY_ID" "$API_BASE" << 'PYEOF'
+import json, sys, os, re
+
+issues_file, branch, agent_id, company_id, api_base = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
+
+def sanitize(s):
+    """Strip chars that could break shell eval"""
+    return re.sub(r'[^a-zA-Z0-9 _.:\-/()\#,\n]', '', s)
+
+def emit_empty(active_hint=""):
+    print('PAPERCLIP_ISSUE_ID=""')
+    print('PAPERCLIP_ISSUE_TITLE=""')
+    print('PAPERCLIP_ISSUE_STATUS=""')
+    print('PAPERCLIP_ISSUE_PRIORITY=""')
+    print('PAPERCLIP_ISSUE_DESCRIPTION=""')
+    print(f'PAPERCLIP_COMPANY_ID="{company_id}"')
+    print(f'PAPERCLIP_API_BASE="{api_base}"')
+    if active_hint:
+        print(f'PAPERCLIP_ACTIVE_ISSUES="{sanitize(active_hint)}"')
+
+def emit_match(issue):
+    print(f'PAPERCLIP_ISSUE_ID="{sanitize(issue.get("identifier",""))}"')
+    print(f'PAPERCLIP_ISSUE_TITLE="{sanitize(issue.get("title",""))}"')
+    print(f'PAPERCLIP_ISSUE_STATUS="{sanitize(issue.get("status",""))}"')
+    print(f'PAPERCLIP_ISSUE_PRIORITY="{sanitize(issue.get("priority",""))}"')
+    print(f'PAPERCLIP_ISSUE_UUID="{issue.get("id","")}"')
+    desc = issue.get("description","") or ""
+    print(f'PAPERCLIP_ISSUE_DESCRIPTION="{sanitize(desc[:200])}"')
+    print(f'PAPERCLIP_COMPANY_ID="{company_id}"')
+    print(f'PAPERCLIP_API_BASE="{api_base}"')
+
+try:
+    with open(issues_file) as f:
+        issues = json.load(f)
+except:
+    emit_empty()
+    sys.exit(0)
+
+# Filter to actionable issues
+active = [i for i in issues if i.get('status') in ('in_progress', 'todo', 'pending')]
+
+if not active:
+    emit_empty()
+    sys.exit(0)
+
+# Strategy 1: explicit agent ID
+if agent_id:
+    matches = [i for i in active if i.get('assigneeAgentId') == agent_id]
+    if matches:
+        in_prog = [i for i in matches if i.get('status') == 'in_progress']
+        emit_match((in_prog or matches)[0])
+        sys.exit(0)
+
+# Strategy 2: branch name matching
+branch_clean = re.sub(r'^[^/]+/', '', branch).lower().replace('-', ' ').replace('_', ' ')
+branch_words = set(branch_clean.split())
+branch_words -= {'the', 'a', 'an', 'and', 'or', 'for', 'to', 'in', 'on', 'of', 'is', 'add', 'fix', 'update', 'check'}
+
+if branch_words:
+    scored = []
+    for i in active:
+        title = (i.get('title') or '').lower()
+        desc = (i.get('description') or '')[:500].lower()
+        text = title + ' ' + desc
+        score = sum(1 for w in branch_words if len(w) > 2 and w in text)
+        if score > 0:
+            scored.append((score, i))
+    scored.sort(key=lambda x: -x[0])
+    if scored and scored[0][0] >= 2:
+        emit_match(scored[0][1])
+        sys.exit(0)
+
+# No match — output active issues as hint
+lines = []
+for i in active[:10]:
+    ident = i.get('identifier','')
+    title = (i.get('title') or '')[:60]
+    status = i.get('status','')
+    lines.append(f'{ident}: {title} [{status}]')
+emit_empty('\n'.join(lines))
+PYEOF

--- a/.claude/skills/gstack/bin/gstack-paperclip-sync
+++ b/.claude/skills/gstack/bin/gstack-paperclip-sync
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# gstack-paperclip-sync — sync a Paperclip issue to GitHub and/or mark done
+# Usage:
+#   gstack-paperclip-sync github PET-42    → create/find matching GitHub issue
+#   gstack-paperclip-sync done PET-42      → mark Paperclip issue as done
+#   gstack-paperclip-sync link PET-42 #123 → add cross-reference comment
+#
+# Reads ~/.paperclip/context.json for API config.
+# Exit 0 always — never blocks the caller.
+set -euo pipefail
+
+ACTION="${1:-}"
+PET_ID="${2:-}"
+EXTRA="${3:-}"
+
+if [ -z "$ACTION" ] || [ -z "$PET_ID" ]; then
+  echo "Usage: gstack-paperclip-sync {github|done|link} PET-XX [extra]"
+  exit 0
+fi
+
+# Load Paperclip config
+CONTEXT_FILE="$HOME/.paperclip/context.json"
+if [ ! -f "$CONTEXT_FILE" ]; then
+  echo "PAPERCLIP_SYNC_RESULT=\"no_config\""
+  exit 0
+fi
+
+API_BASE=$(python3 -c "import json; c=json.load(open('$CONTEXT_FILE')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('apiBase',''))" 2>/dev/null || true)
+COMPANY_ID=$(python3 -c "import json; c=json.load(open('$CONTEXT_FILE')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('companyId',''))" 2>/dev/null || true)
+
+if [ -z "$API_BASE" ] || [ -z "$COMPANY_ID" ]; then
+  echo "PAPERCLIP_SYNC_RESULT=\"no_config\""
+  exit 0
+fi
+
+case "$ACTION" in
+  github)
+    # Create or find a GitHub issue matching this Paperclip issue
+    # First, check if one already exists
+    EXISTING=$(gh issue list --label paperclip --search "$PET_ID" --json number,title --jq ".[0].number" 2>/dev/null || echo "")
+
+    if [ -n "$EXISTING" ]; then
+      echo "PAPERCLIP_SYNC_RESULT=\"exists\""
+      echo "GITHUB_ISSUE_NUMBER=\"$EXISTING\""
+      exit 0
+    fi
+
+    # Fetch Paperclip issue details
+    TMPFILE=$(mktemp /tmp/gstack-paperclip-sync.XXXXXX)
+    trap 'rm -f "$TMPFILE"' EXIT
+    curl -sf "$API_BASE/api/companies/$COMPANY_ID/issues?limit=100" > "$TMPFILE" 2>/dev/null || echo "[]" > "$TMPFILE"
+
+    ISSUE_DATA=$(python3 - "$TMPFILE" "$PET_ID" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    issues = json.load(f)
+pet_id = sys.argv[2]
+for i in issues:
+    if i.get('identifier') == pet_id:
+        title = i.get('title', '')
+        desc = i.get('description', '') or ''
+        priority = i.get('priority', 'medium')
+        status = i.get('status', 'todo')
+        # Truncate description for GH issue body
+        if len(desc) > 2000:
+            desc = desc[:2000] + '\n\n...(truncated)'
+        print(f'TITLE={pet_id}: {title}')
+        print(f'PRIORITY={priority}')
+        print(f'STATUS={status}')
+        # Write body to a temp file to avoid shell quoting issues
+        import tempfile, os
+        body_file = tempfile.mktemp(suffix='.md')
+        with open(body_file, 'w') as bf:
+            bf.write(f'> Synced from Paperclip issue **{pet_id}**\n\n')
+            bf.write(f'**Priority:** {priority}\n')
+            bf.write(f'**Status:** {status}\n\n')
+            bf.write('---\n\n')
+            bf.write(desc)
+        print(f'BODY_FILE={body_file}')
+        sys.exit(0)
+print('NOT_FOUND=true')
+PYEOF
+    )
+
+    if echo "$ISSUE_DATA" | grep -q "NOT_FOUND"; then
+      echo "PAPERCLIP_SYNC_RESULT=\"not_found\""
+      exit 0
+    fi
+
+    eval "$ISSUE_DATA"
+
+    # Create GitHub issue
+    LABELS="paperclip"
+    case "$PRIORITY" in
+      critical) LABELS="paperclip,priority:critical" ;;
+      high)     LABELS="paperclip,priority:high" ;;
+      medium)   LABELS="paperclip,priority:medium" ;;
+      low)      LABELS="paperclip,priority:low" ;;
+    esac
+
+    GH_NUMBER=$(gh issue create --title "$TITLE" --label "$LABELS" --body-file "$BODY_FILE" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
+    rm -f "$BODY_FILE" 2>/dev/null
+
+    if [ -n "$GH_NUMBER" ]; then
+      echo "PAPERCLIP_SYNC_RESULT=\"created\""
+      echo "GITHUB_ISSUE_NUMBER=\"$GH_NUMBER\""
+    else
+      echo "PAPERCLIP_SYNC_RESULT=\"failed\""
+    fi
+    ;;
+
+  done)
+    # Mark a Paperclip issue as done via API
+    # First find the issue UUID
+    TMPFILE=$(mktemp /tmp/gstack-paperclip-sync.XXXXXX)
+    trap 'rm -f "$TMPFILE"' EXIT
+    curl -sf "$API_BASE/api/companies/$COMPANY_ID/issues?limit=100" > "$TMPFILE" 2>/dev/null || echo "[]" > "$TMPFILE"
+
+    ISSUE_UUID=$(python3 -c "
+import json, sys
+with open('$TMPFILE') as f:
+    issues = json.load(f)
+for i in issues:
+    if i.get('identifier') == '$PET_ID':
+        print(i.get('id', ''))
+        sys.exit(0)
+print('')
+" 2>/dev/null || echo "")
+
+    if [ -z "$ISSUE_UUID" ]; then
+      echo "PAPERCLIP_SYNC_RESULT=\"not_found\""
+      exit 0
+    fi
+
+    # Try to mark done via PATCH
+    HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
+      -X PATCH "$API_BASE/api/companies/$COMPANY_ID/issues/$ISSUE_UUID" \
+      -H "Content-Type: application/json" \
+      -d '{"status":"done"}' 2>/dev/null || echo "000")
+
+    if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+      echo "PAPERCLIP_SYNC_RESULT=\"done\""
+    else
+      echo "PAPERCLIP_SYNC_RESULT=\"api_error_$HTTP_CODE\""
+    fi
+    ;;
+
+  link)
+    # Add a cross-reference comment on a GitHub issue
+    GH_NUMBER="${EXTRA/#\#/}"  # Strip leading #
+    if [ -n "$GH_NUMBER" ]; then
+      gh issue comment "$GH_NUMBER" --body "Linked to Paperclip issue **$PET_ID**. PR merged — closing." 2>/dev/null
+      echo "PAPERCLIP_SYNC_RESULT=\"linked\""
+    else
+      echo "PAPERCLIP_SYNC_RESULT=\"no_gh_number\""
+    fi
+    ;;
+
+  *)
+    echo "Unknown action: $ACTION"
+    echo "Usage: gstack-paperclip-sync {github|done|link} PET-XX [extra]"
+    ;;
+esac

--- a/.claude/skills/gstack/land-and-deploy/SKILL.md.tmpl
+++ b/.claude/skills/gstack/land-and-deploy/SKILL.md.tmpl
@@ -825,6 +825,30 @@ After a successful revert: Tell the user "Revert pushed to {base}. The deploy sh
 
 ---
 
+## Step 8.5: Paperclip Completion
+
+After a successful merge (not reverted), mark any linked Paperclip issue as done.
+
+1. **Read the PR body** for a Paperclip reference:
+```bash
+PR_BODY=$(gh pr view --json body --jq .body 2>/dev/null || echo "")
+PET_ID=$(echo "$PR_BODY" | grep -oE 'PET-[0-9]+' | head -1)
+```
+
+2. **If a PET-xx identifier was found**, mark it done in Paperclip:
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync done $PET_ID 2>/dev/null)"
+```
+
+3. **Report the result:**
+   - If `PAPERCLIP_SYNC_RESULT="done"`: Print "Paperclip: $PET_ID marked as done."
+   - If `PAPERCLIP_SYNC_RESULT="api_error_*"`: Print "Paperclip: Could not mark $PET_ID done (API returned $HTTP_CODE). You may need to update it manually."
+   - If no PET-xx found: Continue silently.
+
+This step is automatic — never ask for confirmation. Failure does not block the deploy report.
+
+---
+
 ## Step 9: Deploy report
 
 Create the deploy report directory:

--- a/.claude/skills/gstack/paperclip/SKILL.md
+++ b/.claude/skills/gstack/paperclip/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: paperclip
+preamble-tier: 4
+version: 1.0.0
+description: |
+  Paperclip bridge: sync Paperclip tasks to GitHub issues, mark done on merge,
+  show agent status, and audit drift between the two systems. The "adult in the
+  room" that makes sure fast-moving Paperclip work lands properly in GitHub.
+  Use when: "sync paperclip", "paperclip status", "what's paperclip doing",
+  "sync issues", "mark done", "audit paperclip". (gstack)
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+<!-- Preamble: gstack paperclip bridge -->
+
+# /paperclip — Paperclip ↔ GitHub Bridge
+
+You are the **Release Governance Engineer** — the adult in the room between Paperclip
+(the fast-moving agent orchestrator) and GitHub (the system of record). Your job is to
+make sure every piece of work that Paperclip assigns gets tracked, reviewed, and landed
+properly in the repo.
+
+## User-invocable
+When the user types `/paperclip`, run this skill.
+
+## Arguments
+- `/paperclip` — default: show status dashboard, then offer actions
+- `/paperclip status` — show the full status dashboard
+- `/paperclip sync` — sync all active Paperclip issues to GitHub issues
+- `/paperclip audit` — find drift: issues in one system but not the other
+- `/paperclip done PET-XX` — mark a Paperclip issue as done
+- `/paperclip agents` — show all agents and their current assignments
+
+---
+
+## Step 0: Load Paperclip Config
+
+```bash
+CONTEXT_FILE="$HOME/.paperclip/context.json"
+```
+
+Read `~/.paperclip/context.json` to get `apiBase` and `companyId`. If the file doesn't
+exist, **STOP**: "Paperclip isn't configured on this machine. Make sure Paperclip is
+running at localhost:3100 and has a context file at ~/.paperclip/context.json."
+
+Extract `API_BASE` and `COMPANY_ID` from the config file using python3:
+```bash
+API_BASE=$(python3 -c "import json; c=json.load(open('$HOME/.paperclip/context.json')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('apiBase',''))")
+COMPANY_ID=$(python3 -c "import json; c=json.load(open('$HOME/.paperclip/context.json')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('companyId',''))")
+```
+
+Fetch all Paperclip issues and agents to a temp file (avoids shell quoting issues):
+```bash
+curl -sf "$API_BASE/api/companies/$COMPANY_ID/issues?limit=200" > /tmp/paperclip-issues.json
+curl -sf "$API_BASE/api/companies/$COMPANY_ID/agents" > /tmp/paperclip-agents.json
+```
+
+If curl fails, **STOP**: "Can't reach Paperclip at $API_BASE. Is it running?"
+
+---
+
+## Step 1: Parse Arguments and Route
+
+Parse the user's argument from the `/paperclip` invocation:
+
+- No argument or `status` → go to **Step 2: Status Dashboard**
+- `sync` → go to **Step 3: Sync All**
+- `audit` → go to **Step 4: Audit**
+- `done PET-XX` → go to **Step 5: Mark Done**
+- `agents` → go to **Step 6: Agent Status**
+
+---
+
+## Step 2: Status Dashboard
+
+Build a comprehensive view of what's happening across both systems.
+
+### 2a: Parse Paperclip issues
+
+Use python3 to read `/tmp/paperclip-issues.json` and categorize:
+
+```bash
+python3 - << 'PYEOF'
+import json
+
+with open('/tmp/paperclip-issues.json') as f:
+    issues = json.load(f)
+
+by_status = {}
+for i in issues:
+    s = i.get('status', 'unknown')
+    by_status.setdefault(s, []).append(i)
+
+print(f"Total: {len(issues)}")
+for status in ['in_progress', 'todo', 'pending', 'blocked', 'in_review', 'done', 'backlog']:
+    items = by_status.get(status, [])
+    if items:
+        print(f"\n{status.upper()} ({len(items)}):")
+        for i in items:
+            ident = i.get('identifier', '?')
+            title = (i.get('title') or '')[:55]
+            priority = i.get('priority', '?')
+            agent = i.get('executionAgentNameKey') or 'unassigned'
+            run = i.get('activeRun')
+            run_status = f" [run:{run['status']}]" if run else ''
+            print(f"  {ident:8s} {priority:10s} {agent:18s} {title}{run_status}")
+PYEOF
+```
+
+### 2b: Check GitHub issue sync status
+
+For each active Paperclip issue (in_progress, todo, pending), check if a matching
+GitHub issue exists:
+
+```bash
+# Get all GitHub issues with paperclip label
+gh issue list --label paperclip --state all --json number,title,state --limit 200 2>/dev/null || echo "[]"
+```
+
+Parse the results and cross-reference with Paperclip issues. For each Paperclip issue,
+check if a GitHub issue exists with the `PET-XX` identifier in the title.
+
+### 2c: Check open PRs for Paperclip references
+
+```bash
+gh pr list --state open --json number,title,body,headRefName --limit 50 2>/dev/null || echo "[]"
+```
+
+Scan PR bodies for `PET-XX` patterns. Note which Paperclip issues have associated PRs.
+
+### 2d: Display the dashboard
+
+Output a formatted dashboard:
+
+```
+╔══════════════════════════════════════════════════════════╗
+║              PAPERCLIP ↔ GITHUB STATUS                    ║
+╠══════════════════════════════════════════════════════════╣
+║                                                            ║
+║  PAPERCLIP                                                 ║
+║  Total issues:  NN                                         ║
+║  Active:        NN (in_progress + todo)                    ║
+║  Running:       NN agents currently executing              ║
+║  Done:          NN                                         ║
+║                                                            ║
+║  GITHUB SYNC                                               ║
+║  Synced issues: NN / NN active (paperclip label)           ║
+║  Open PRs:      NN referencing PET-XX                      ║
+║  Missing sync:  NN Paperclip issues without GitHub issue   ║
+║                                                            ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+Then list the **unsynced** issues (Paperclip issues without a matching GitHub issue):
+
+```
+UNSYNCED — these Paperclip issues have no GitHub issue:
+  PET-58  critical  Quick-Log care events from dashboard
+  PET-75  high      Define product analytics KPI framework
+  ...
+```
+
+### 2e: Offer actions
+
+Use AskUserQuestion:
+- "Here's the current state. What would you like to do?"
+- A) Sync all unsynced issues to GitHub (creates GitHub issues with `paperclip` label)
+- B) Run a full audit (check for drift in both directions)
+- C) Nothing — just wanted the status
+
+If A → go to Step 3. If B → go to Step 4. If C → done.
+
+---
+
+## Step 3: Sync All
+
+Sync all active Paperclip issues to GitHub. For each Paperclip issue that is
+`in_progress`, `todo`, or `pending` and does NOT have a matching GitHub issue:
+
+1. **Check if GitHub issue exists:**
+```bash
+gh issue list --label paperclip --search "PET-XX" --json number,title --jq '.[0].number' 2>/dev/null
+```
+
+2. **If not found, create it:**
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync github PET-XX 2>/dev/null)"
+```
+
+3. **Report each sync:**
+   - `✓ PET-XX → GitHub #NN (created)`
+   - `· PET-XX → GitHub #NN (already exists)`
+   - `✗ PET-XX → failed to create`
+
+4. **For issues that are `done` in Paperclip but open on GitHub**, close the GitHub issue:
+```bash
+gh issue close $GH_NUMBER --comment "Closed — Paperclip issue $PET_ID is marked done."
+```
+
+5. **Summary:**
+```
+Sync complete:
+  Created:  N new GitHub issues
+  Existing: N already synced
+  Closed:   N GitHub issues (done in Paperclip)
+  Failed:   N (list them)
+```
+
+This step is fully automatic — no confirmation needed per issue. The user said `/paperclip sync`.
+
+---
+
+## Step 4: Audit
+
+Find drift between Paperclip and GitHub. Three categories:
+
+### 4a: Paperclip issues with no GitHub issue
+
+Active Paperclip issues (`in_progress`, `todo`, `pending`) that don't have a matching
+GitHub issue with the `paperclip` label. These need syncing.
+
+### 4b: GitHub issues with `paperclip` label that don't match a Paperclip issue
+
+This can happen if:
+- The Paperclip issue was deleted
+- The GitHub issue title was edited and no longer contains `PET-XX`
+- Someone manually created a `paperclip`-labeled issue
+
+### 4c: Status mismatches
+
+Issues that exist in both systems but have conflicting status:
+- Done in Paperclip but still open on GitHub
+- Open in Paperclip but closed on GitHub
+- Priority changed in Paperclip but not reflected in GitHub labels
+
+### 4d: PR coverage
+
+Active Paperclip issues that have no associated PR (open or merged). These represent
+work that was assigned but hasn't produced code yet.
+
+### 4e: Output the audit report
+
+```
+PAPERCLIP ↔ GITHUB AUDIT
+═════════════════════════
+
+MISSING FROM GITHUB (N):
+  PET-XX: <title> — needs sync
+  ...
+
+ORPHANED GITHUB ISSUES (N):
+  #NN: <title> — no matching Paperclip issue
+  ...
+
+STATUS MISMATCHES (N):
+  PET-XX ↔ #NN: Paperclip=done, GitHub=open — should close
+  ...
+
+NO PR COVERAGE (N):
+  PET-XX: <title> — in_progress but no PR found
+  ...
+
+HEALTH: X/Y issues synced (Z%)
+```
+
+### 4f: Offer fixes
+
+If any drift was found, use AskUserQuestion:
+- A) Fix all automatically (sync missing, close done, skip orphans)
+- B) Fix one by one (walk through each issue)
+- C) Just the report — I'll handle it
+
+---
+
+## Step 5: Mark Done
+
+Mark a specific Paperclip issue as done.
+
+1. Parse the PET-XX identifier from the argument.
+
+2. Run:
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync done PET-XX 2>/dev/null)"
+```
+
+3. If successful, also close the matching GitHub issue (if one exists):
+```bash
+GH_NUMBER=$(gh issue list --label paperclip --search "PET-XX" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$GH_NUMBER" ]; then
+  gh issue close "$GH_NUMBER" --comment "Closed — PET-XX marked done via /paperclip."
+fi
+```
+
+4. Report:
+   - "PET-XX marked done in Paperclip. GitHub issue #NN closed."
+   - Or: "PET-XX marked done in Paperclip. No matching GitHub issue found."
+   - Or: "Failed to mark PET-XX done: <error>"
+
+---
+
+## Step 6: Agent Status
+
+Show all Paperclip agents and what they're working on.
+
+Parse `/tmp/paperclip-agents.json` and `/tmp/paperclip-issues.json`:
+
+```bash
+python3 - << 'PYEOF'
+import json
+
+with open('/tmp/paperclip-agents.json') as f:
+    agents = json.load(f)
+with open('/tmp/paperclip-issues.json') as f:
+    issues = json.load(f)
+
+# Build agent → issues mapping
+agent_issues = {}
+for i in issues:
+    aid = i.get('assigneeAgentId')
+    if aid:
+        agent_issues.setdefault(aid, []).append(i)
+
+for a in sorted(agents, key=lambda x: x.get('name', '')):
+    name = a.get('name', '?')
+    title = a.get('title', '')
+    status = a.get('status', '?')
+    aid = a.get('id')
+    my_issues = agent_issues.get(aid, [])
+    active = [i for i in my_issues if i.get('status') in ('in_progress', 'todo')]
+    done = [i for i in my_issues if i.get('status') == 'done']
+    running = [i for i in my_issues if i.get('activeRun') and i['activeRun'].get('status') == 'running']
+
+    icon = '🟢' if running else ('🟡' if active else '⚪')
+    print(f"{icon} {name} ({title}) — {len(active)} active, {len(done)} done")
+    for i in running:
+        print(f"   ▶ {i['identifier']}: {i.get('title','')[:50]}")
+    for i in active:
+        if not (i.get('activeRun') and i['activeRun'].get('status') == 'running'):
+            print(f"   · {i['identifier']}: {i.get('title','')[:50]} [{i['status']}]")
+PYEOF
+```
+
+Output the result, then offer:
+- "Any idle agents you want to assign work to? Or any running agents you want to check on?"
+
+---
+
+## Important Rules
+
+- **Never block on Paperclip API failures.** If the API is down, report it and continue
+  with what you can do from GitHub alone.
+- **The `paperclip` label is the sync key.** Every GitHub issue created by this skill
+  gets the `paperclip` label. Never remove it — it's how we find synced issues.
+- **PET-XX in the title is the cross-reference.** GitHub issue titles always start with
+  `PET-XX:` so we can match them back to Paperclip.
+- **GitHub is the system of record for code.** Paperclip assigns work, but PRs, reviews,
+  and merges happen on GitHub. This skill bridges the gap.
+- **Be idempotent.** Running `/paperclip sync` twice should not create duplicate issues.
+  Always check before creating.
+- **Priority label mapping:** critical → `priority:critical`, high → `priority:high`,
+  medium → `priority:medium`, low → `priority:low`.

--- a/.claude/skills/gstack/paperclip/SKILL.md.tmpl
+++ b/.claude/skills/gstack/paperclip/SKILL.md.tmpl
@@ -1,0 +1,368 @@
+---
+name: paperclip
+preamble-tier: 4
+version: 1.0.0
+description: |
+  Paperclip bridge: sync Paperclip tasks to GitHub issues, mark done on merge,
+  show agent status, and audit drift between the two systems. The "adult in the
+  room" that makes sure fast-moving Paperclip work lands properly in GitHub.
+  Use when: "sync paperclip", "paperclip status", "what's paperclip doing",
+  "sync issues", "mark done", "audit paperclip". (gstack)
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /paperclip — Paperclip ↔ GitHub Bridge
+
+You are the **Release Governance Engineer** — the adult in the room between Paperclip
+(the fast-moving agent orchestrator) and GitHub (the system of record). Your job is to
+make sure every piece of work that Paperclip assigns gets tracked, reviewed, and landed
+properly in the repo.
+
+## User-invocable
+When the user types `/paperclip`, run this skill.
+
+## Arguments
+- `/paperclip` — default: show status dashboard, then offer actions
+- `/paperclip status` — show the full status dashboard
+- `/paperclip sync` — sync all active Paperclip issues to GitHub issues
+- `/paperclip audit` — find drift: issues in one system but not the other
+- `/paperclip done PET-XX` — mark a Paperclip issue as done
+- `/paperclip agents` — show all agents and their current assignments
+
+---
+
+## Step 0: Load Paperclip Config
+
+```bash
+CONTEXT_FILE="$HOME/.paperclip/context.json"
+```
+
+Read `~/.paperclip/context.json` to get `apiBase` and `companyId`. If the file doesn't
+exist, **STOP**: "Paperclip isn't configured on this machine. Make sure Paperclip is
+running at localhost:3100 and has a context file at ~/.paperclip/context.json."
+
+Extract `API_BASE` and `COMPANY_ID` from the config file using python3:
+```bash
+API_BASE=$(python3 -c "import json; c=json.load(open('$HOME/.paperclip/context.json')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('apiBase',''))")
+COMPANY_ID=$(python3 -c "import json; c=json.load(open('$HOME/.paperclip/context.json')); p=c.get('currentProfile','default'); print(c['profiles'][p].get('companyId',''))")
+```
+
+Fetch all Paperclip issues and agents to a temp file (avoids shell quoting issues):
+```bash
+curl -sf "$API_BASE/api/companies/$COMPANY_ID/issues?limit=200" > /tmp/paperclip-issues.json
+curl -sf "$API_BASE/api/companies/$COMPANY_ID/agents" > /tmp/paperclip-agents.json
+```
+
+If curl fails, **STOP**: "Can't reach Paperclip at $API_BASE. Is it running?"
+
+---
+
+## Step 1: Parse Arguments and Route
+
+Parse the user's argument from the `/paperclip` invocation:
+
+- No argument or `status` → go to **Step 2: Status Dashboard**
+- `sync` → go to **Step 3: Sync All**
+- `audit` → go to **Step 4: Audit**
+- `done PET-XX` → go to **Step 5: Mark Done**
+- `agents` → go to **Step 6: Agent Status**
+
+---
+
+## Step 2: Status Dashboard
+
+Build a comprehensive view of what's happening across both systems.
+
+### 2a: Parse Paperclip issues
+
+Use python3 to read `/tmp/paperclip-issues.json` and categorize:
+
+```bash
+python3 - << 'PYEOF'
+import json
+
+with open('/tmp/paperclip-issues.json') as f:
+    issues = json.load(f)
+
+by_status = {}
+for i in issues:
+    s = i.get('status', 'unknown')
+    by_status.setdefault(s, []).append(i)
+
+print(f"Total: {len(issues)}")
+for status in ['in_progress', 'todo', 'pending', 'blocked', 'in_review', 'done', 'backlog']:
+    items = by_status.get(status, [])
+    if items:
+        print(f"\n{status.upper()} ({len(items)}):")
+        for i in items:
+            ident = i.get('identifier', '?')
+            title = (i.get('title') or '')[:55]
+            priority = i.get('priority', '?')
+            agent = i.get('executionAgentNameKey') or 'unassigned'
+            run = i.get('activeRun')
+            run_status = f" [run:{run['status']}]" if run else ''
+            print(f"  {ident:8s} {priority:10s} {agent:18s} {title}{run_status}")
+PYEOF
+```
+
+### 2b: Check GitHub issue sync status
+
+For each active Paperclip issue (in_progress, todo, pending), check if a matching
+GitHub issue exists:
+
+```bash
+# Get all GitHub issues with paperclip label
+gh issue list --label paperclip --state all --json number,title,state --limit 200 2>/dev/null || echo "[]"
+```
+
+Parse the results and cross-reference with Paperclip issues. For each Paperclip issue,
+check if a GitHub issue exists with the `PET-XX` identifier in the title.
+
+### 2c: Check open PRs for Paperclip references
+
+```bash
+gh pr list --state open --json number,title,body,headRefName --limit 50 2>/dev/null || echo "[]"
+```
+
+Scan PR bodies for `PET-XX` patterns. Note which Paperclip issues have associated PRs.
+
+### 2d: Display the dashboard
+
+Output a formatted dashboard:
+
+```
+╔══════════════════════════════════════════════════════════╗
+║              PAPERCLIP ↔ GITHUB STATUS                    ║
+╠══════════════════════════════════════════════════════════╣
+║                                                            ║
+║  PAPERCLIP                                                 ║
+║  Total issues:  NN                                         ║
+║  Active:        NN (in_progress + todo)                    ║
+║  Running:       NN agents currently executing              ║
+║  Done:          NN                                         ║
+║                                                            ║
+║  GITHUB SYNC                                               ║
+║  Synced issues: NN / NN active (paperclip label)           ║
+║  Open PRs:      NN referencing PET-XX                      ║
+║  Missing sync:  NN Paperclip issues without GitHub issue   ║
+║                                                            ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+Then list the **unsynced** issues (Paperclip issues without a matching GitHub issue):
+
+```
+UNSYNCED — these Paperclip issues have no GitHub issue:
+  PET-58  critical  Quick-Log care events from dashboard
+  PET-75  high      Define product analytics KPI framework
+  ...
+```
+
+### 2e: Offer actions
+
+Use AskUserQuestion:
+- "Here's the current state. What would you like to do?"
+- A) Sync all unsynced issues to GitHub (creates GitHub issues with `paperclip` label)
+- B) Run a full audit (check for drift in both directions)
+- C) Nothing — just wanted the status
+
+If A → go to Step 3. If B → go to Step 4. If C → done.
+
+---
+
+## Step 3: Sync All
+
+Sync all active Paperclip issues to GitHub. For each Paperclip issue that is
+`in_progress`, `todo`, or `pending` and does NOT have a matching GitHub issue:
+
+1. **Check if GitHub issue exists:**
+```bash
+gh issue list --label paperclip --search "PET-XX" --json number,title --jq '.[0].number' 2>/dev/null
+```
+
+2. **If not found, create it:**
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync github PET-XX 2>/dev/null)"
+```
+
+3. **Report each sync:**
+   - `✓ PET-XX → GitHub #NN (created)`
+   - `· PET-XX → GitHub #NN (already exists)`
+   - `✗ PET-XX → failed to create`
+
+4. **For issues that are `done` in Paperclip but open on GitHub**, close the GitHub issue:
+```bash
+gh issue close $GH_NUMBER --comment "Closed — Paperclip issue $PET_ID is marked done."
+```
+
+5. **Summary:**
+```
+Sync complete:
+  Created:  N new GitHub issues
+  Existing: N already synced
+  Closed:   N GitHub issues (done in Paperclip)
+  Failed:   N (list them)
+```
+
+This step is fully automatic — no confirmation needed per issue. The user said `/paperclip sync`.
+
+---
+
+## Step 4: Audit
+
+Find drift between Paperclip and GitHub. Three categories:
+
+### 4a: Paperclip issues with no GitHub issue
+
+Active Paperclip issues (`in_progress`, `todo`, `pending`) that don't have a matching
+GitHub issue with the `paperclip` label. These need syncing.
+
+### 4b: GitHub issues with `paperclip` label that don't match a Paperclip issue
+
+This can happen if:
+- The Paperclip issue was deleted
+- The GitHub issue title was edited and no longer contains `PET-XX`
+- Someone manually created a `paperclip`-labeled issue
+
+### 4c: Status mismatches
+
+Issues that exist in both systems but have conflicting status:
+- Done in Paperclip but still open on GitHub
+- Open in Paperclip but closed on GitHub
+- Priority changed in Paperclip but not reflected in GitHub labels
+
+### 4d: PR coverage
+
+Active Paperclip issues that have no associated PR (open or merged). These represent
+work that was assigned but hasn't produced code yet.
+
+### 4e: Output the audit report
+
+```
+PAPERCLIP ↔ GITHUB AUDIT
+═════════════════════════
+
+MISSING FROM GITHUB (N):
+  PET-XX: <title> — needs sync
+  ...
+
+ORPHANED GITHUB ISSUES (N):
+  #NN: <title> — no matching Paperclip issue
+  ...
+
+STATUS MISMATCHES (N):
+  PET-XX ↔ #NN: Paperclip=done, GitHub=open — should close
+  ...
+
+NO PR COVERAGE (N):
+  PET-XX: <title> — in_progress but no PR found
+  ...
+
+HEALTH: X/Y issues synced (Z%)
+```
+
+### 4f: Offer fixes
+
+If any drift was found, use AskUserQuestion:
+- A) Fix all automatically (sync missing, close done, skip orphans)
+- B) Fix one by one (walk through each issue)
+- C) Just the report — I'll handle it
+
+---
+
+## Step 5: Mark Done
+
+Mark a specific Paperclip issue as done.
+
+1. Parse the PET-XX identifier from the argument.
+
+2. Run:
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync done PET-XX 2>/dev/null)"
+```
+
+3. If successful, also close the matching GitHub issue (if one exists):
+```bash
+GH_NUMBER=$(gh issue list --label paperclip --search "PET-XX" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$GH_NUMBER" ]; then
+  gh issue close "$GH_NUMBER" --comment "Closed — PET-XX marked done via /paperclip."
+fi
+```
+
+4. Report:
+   - "PET-XX marked done in Paperclip. GitHub issue #NN closed."
+   - Or: "PET-XX marked done in Paperclip. No matching GitHub issue found."
+   - Or: "Failed to mark PET-XX done: <error>"
+
+---
+
+## Step 6: Agent Status
+
+Show all Paperclip agents and what they're working on.
+
+Parse `/tmp/paperclip-agents.json` and `/tmp/paperclip-issues.json`:
+
+```bash
+python3 - << 'PYEOF'
+import json
+
+with open('/tmp/paperclip-agents.json') as f:
+    agents = json.load(f)
+with open('/tmp/paperclip-issues.json') as f:
+    issues = json.load(f)
+
+# Build agent → issues mapping
+agent_issues = {}
+for i in issues:
+    aid = i.get('assigneeAgentId')
+    if aid:
+        agent_issues.setdefault(aid, []).append(i)
+
+for a in sorted(agents, key=lambda x: x.get('name', '')):
+    name = a.get('name', '?')
+    title = a.get('title', '')
+    status = a.get('status', '?')
+    aid = a.get('id')
+    my_issues = agent_issues.get(aid, [])
+    active = [i for i in my_issues if i.get('status') in ('in_progress', 'todo')]
+    done = [i for i in my_issues if i.get('status') == 'done']
+    running = [i for i in my_issues if i.get('activeRun') and i['activeRun'].get('status') == 'running']
+
+    icon = '🟢' if running else ('🟡' if active else '⚪')
+    print(f"{icon} {name} ({title}) — {len(active)} active, {len(done)} done")
+    for i in running:
+        print(f"   ▶ {i['identifier']}: {i.get('title','')[:50]}")
+    for i in active:
+        if not (i.get('activeRun') and i['activeRun'].get('status') == 'running'):
+            print(f"   · {i['identifier']}: {i.get('title','')[:50]} [{i['status']}]")
+PYEOF
+```
+
+Output the result, then offer:
+- "Any idle agents you want to assign work to? Or any running agents you want to check on?"
+
+---
+
+## Important Rules
+
+- **Never block on Paperclip API failures.** If the API is down, report it and continue
+  with what you can do from GitHub alone.
+- **The `paperclip` label is the sync key.** Every GitHub issue created by this skill
+  gets the `paperclip` label. Never remove it — it's how we find synced issues.
+- **PET-XX in the title is the cross-reference.** GitHub issue titles always start with
+  `PET-XX:` so we can match them back to Paperclip.
+- **GitHub is the system of record for code.** Paperclip assigns work, but PRs, reviews,
+  and merges happen on GitHub. This skill bridges the gap.
+- **Be idempotent.** Running `/paperclip sync` twice should not create duplicate issues.
+  Always check before creating.
+- **Priority label mapping:** critical → `priority:critical`, high → `priority:high`,
+  medium → `priority:medium`, low → `priority:low`.

--- a/.claude/skills/gstack/review/SKILL.md.tmpl
+++ b/.claude/skills/gstack/review/SKILL.md.tmpl
@@ -44,7 +44,16 @@ Before reviewing code quality, check: **did they build what was requested — no
 1. Read `TODOS.md` (if it exists). Read PR description (`gh pr view --json body --jq .body 2>/dev/null || true`).
    Read commit messages (`git log origin/<base>..HEAD --oneline`).
    **If no PR exists:** rely on commit messages and TODOS.md for stated intent — this is the common case since /review runs before /ship creates the PR.
-2. Identify the **stated intent** — what was this branch supposed to accomplish?
+
+   **Paperclip context:** Query Paperclip for the assigned task to supplement stated intent:
+   ```bash
+   eval "$(~/.claude/skills/gstack/bin/gstack-paperclip 2>/dev/null)"
+   ```
+   If `PAPERCLIP_ISSUE_ID` is non-empty, include the Paperclip task title and description
+   as additional "stated intent" for scope drift detection. Print:
+   "Paperclip context: $PAPERCLIP_ISSUE_ID — $PAPERCLIP_ISSUE_TITLE"
+
+2. Identify the **stated intent** — what was this branch supposed to accomplish? Include the Paperclip task description if available — it often contains the most detailed acceptance criteria.
 3. Run `git diff origin/<base>...HEAD --stat` and compare the files changed against the stated intent.
 
 {{PLAN_COMPLETION_AUDIT_REVIEW}}

--- a/.claude/skills/gstack/ship/SKILL.md.tmpl
+++ b/.claude/skills/gstack/ship/SKILL.md.tmpl
@@ -54,6 +54,24 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 
 ---
 
+## Step 0.5: Paperclip Context
+
+Query Paperclip for the current agent's active task. This provides context for the PR body and enables GitHub issue sync.
+
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip 2>/dev/null)"
+```
+
+If `PAPERCLIP_ISSUE_ID` is non-empty, note it for later steps. Print:
+"Paperclip task: $PAPERCLIP_ISSUE_ID — $PAPERCLIP_ISSUE_TITLE [$PAPERCLIP_ISSUE_STATUS]"
+
+If empty but `PAPERCLIP_ACTIVE_ISSUES` is non-empty, print:
+"No Paperclip task matched this branch. Active issues:\n$PAPERCLIP_ACTIVE_ISSUES"
+
+If Paperclip is not configured, continue silently.
+
+---
+
 ## Step 1: Pre-flight
 
 1. Check the current branch. If on the base branch or the repo's default branch, **abort**: "You're on the base branch. Ship from a feature branch."
@@ -525,6 +543,10 @@ you missed it.>
 <If TODOS.md created or reorganized: note that>
 <If TODOS.md doesn't exist and user skipped: omit this section>
 
+## Paperclip
+<If PAPERCLIP_ISSUE_ID was set in Step 0.5: "Tracks Paperclip issue **PET-XX** — <title> (priority: <priority>)">
+<If not set: omit this section entirely>
+
 ## Test plan
 - [x] All Rails tests pass (N runs, 0 failures)
 - [x] All Vitest tests pass (N tests)
@@ -553,7 +575,30 @@ EOF
 **If neither CLI is available:**
 Print the branch name, remote URL, and instruct the user to create the PR/MR manually via the web UI. Do not stop — the code is pushed and ready.
 
-**Output the PR/MR URL** — then proceed to Step 8.5.
+**Output the PR/MR URL** — then proceed to Step 8.25.
+
+---
+
+## Step 8.25: Paperclip → GitHub Issue Sync
+
+If `PAPERCLIP_ISSUE_ID` was set in Step 0.5, ensure there is a matching GitHub issue and link it to this PR.
+
+1. **Create or find the GitHub issue:**
+
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paperclip-sync github $PAPERCLIP_ISSUE_ID 2>/dev/null)"
+```
+
+2. **If a GitHub issue was created or found** (`GITHUB_ISSUE_NUMBER` is set):
+   - Edit the PR to add `Closes #<GITHUB_ISSUE_NUMBER>` to the body (so the issue auto-closes on merge):
+   ```bash
+   gh pr edit --add-body "Closes #$GITHUB_ISSUE_NUMBER"
+   ```
+   - Print: "Synced Paperclip $PAPERCLIP_ISSUE_ID → GitHub issue #$GITHUB_ISSUE_NUMBER (will auto-close on merge)"
+
+3. **If sync failed or no Paperclip issue:** Continue silently.
+
+This step is automatic — never ask for confirmation.
 
 ---
 

--- a/.claude/skills/paperclip
+++ b/.claude/skills/paperclip
@@ -1,0 +1,1 @@
+gstack/paperclip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ This project uses 9 specialized Claude Code agents, each in its own git worktree
 - **petforce-guardrails** — .claude/skills/petforce-guardrails — auto-loads, read before touching packages/
 
 ### gstack (`.claude/skills/gstack`)
-Available skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/design-consultation`, `/design-shotgun`, `/design-html`, `/review`, `/ship`, `/land-and-deploy`, `/canary`, `/benchmark`, `/browse`, `/connect-chrome`, `/qa`, `/qa-only`, `/design-review`, `/setup-browser-cookies`, `/setup-deploy`, `/retro`, `/investigate`, `/document-release`, `/codex`, `/cso`, `/autoplan`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, `/gstack-upgrade`, `/learn`
+Available skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/design-consultation`, `/design-shotgun`, `/design-html`, `/review`, `/ship`, `/land-and-deploy`, `/canary`, `/benchmark`, `/browse`, `/connect-chrome`, `/qa`, `/qa-only`, `/design-review`, `/setup-browser-cookies`, `/setup-deploy`, `/retro`, `/investigate`, `/document-release`, `/codex`, `/cso`, `/autoplan`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, `/gstack-upgrade`, `/learn`, `/paperclip`
 
 Use `/browse` from gstack for all web browsing. Never use `mcp__claude-in-chrome__*` tools.
 
@@ -170,3 +170,4 @@ Key routing rules:
 - Design system, brand → invoke design-consultation
 - Visual audit, design polish → invoke design-review
 - Architecture review → invoke plan-eng-review
+- Paperclip status, sync issues, "what's paperclip doing", audit drift → invoke paperclip


### PR DESCRIPTION
## Summary
- **New `/paperclip` gstack skill** with 5 modes: status dashboard, bulk sync to GitHub issues, drift audit, mark-done, and agent overview
- **New helper scripts**: `gstack-paperclip` (query Paperclip API, match branch/agent to task) and `gstack-paperclip-sync` (create GitHub issues, mark done, cross-link)
- **`/ship` integration**: Step 0.5 queries Paperclip for active task, PR body gets `## Paperclip` section, Step 8.25 auto-creates GitHub issue with `paperclip` label and adds `Closes #N`
- **`/review` integration**: Scope drift detection now uses Paperclip task acceptance criteria as additional stated intent
- **`/land-and-deploy` integration**: Step 8.5 marks Paperclip issue done after successful merge

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor (no behavior change)
- [ ] Docs only

## Closes
N/A — this is new infrastructure, not tied to an existing issue.

## Breaking changes
None. All changes are additive — new skill, new helper scripts, and new optional steps in existing skill templates. Existing `/ship`, `/review`, and `/land-and-deploy` behavior is unchanged when Paperclip is not configured.

## Documentation
CLAUDE.md updated with `/paperclip` in the gstack skill list and routing rules section.

## Test plan
- [x] `gstack-paperclip` tested with explicit agent ID — correctly returns PET-18 for mobile engineer
- [x] `gstack-paperclip` tested with no match — correctly outputs empty vars and active issues hint
- [x] `gstack-paperclip` handles JSON with special characters (single quotes in descriptions)
- [x] Skill symlink created and discoverable
- [x] CLAUDE.md updated with `/paperclip` in skill list and routing rules

## Size check
+1112 lines — larger than 400 but this is a single cohesive feature (skill template + 2 helper scripts + 3 template modifications). The skill template and helper scripts can't be meaningfully split since they form one integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)