### PR TITLE
fix: resolve 3 recurring CI failures across workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
         run: pnpm --filter=@petforce/db db:migrate
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NODE_OPTIONS: "--dns-result-order=ipv4first"
 
       # Deploy API to Railway
       - name: Install Railway CLI

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -29,9 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -93,9 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -83,6 +83,7 @@ jobs:
   check-template:
     name: PR template check
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## Summary
- Skip PR template check for Dependabot/bot PRs that will never match the template
- Force IPv4 DNS resolution for database migrations to avoid IPv6 ENETUNREACH on GitHub Actions runners
- Bump pnpm/action-setup from v4 to v5 and drop explicit version param to avoid conflict with packageManager field

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Closes
Fixes recurring CI failures on PR Metadata (6 failures), Deploy (3 failures), and Mobile E2E (1 failure) workflows.

## Breaking changes
None.

## Documentation
No doc changes needed — CI workflow fixes only.

## Test plan
- [ ] Open a Dependabot PR and verify PR Metadata workflow passes (or skips template check)
- [ ] Merge to main and verify Deploy workflow succeeds (db migration connects via IPv4)
- [ ] Push mobile changes and verify Mobile E2E workflow gets past pnpm setup

## Size check
+4 / -6 lines across 3 workflow files. Minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)