### PR TITLE
feat: add species-based feeding schedule templates (PET-64)

### DIFF
--- a/apps/web/src/components/feeding-manage-modal.tsx
+++ b/apps/web/src/components/feeding-manage-modal.tsx
@@ -6,6 +6,8 @@ import { Modal } from "./modal";
 import {
   FEEDING_LABEL_SUGGESTIONS,
   FEEDING_TIME_PRESETS,
+  FEEDING_SCHEDULE_TEMPLATES,
+  PET_SPECIES_LABELS,
 } from "@petforce/core";
 
 interface FeedingManageModalProps {
@@ -66,10 +68,33 @@ export function FeedingManageModal({ householdId, onClose }: FeedingManageModalP
   // Auto-select first pet if only one
   const effectivePetId = petId || (pets.length === 1 ? pets[0].id : "");
 
+  const [applyingTemplate, setApplyingTemplate] = useState(false);
+
   const handleSuggestion = (suggestion: string) => {
     setLabel(suggestion);
     const preset = FEEDING_TIME_PRESETS[suggestion];
     if (preset) setTime(preset);
+  };
+
+  const selectedPet = pets.find((p) => p.id === effectivePetId);
+  const petSpecies = selectedPet?.species ?? "other";
+  const templates = FEEDING_SCHEDULE_TEMPLATES[petSpecies] ?? FEEDING_SCHEDULE_TEMPLATES["other"];
+  const petHasSchedules = schedules.some((s) => s.petId === effectivePetId);
+
+  const handleApplyTemplate = async () => {
+    if (!effectivePetId || !templates.length) return;
+    setApplyingTemplate(true);
+    for (const t of templates) {
+      await createMut.mutateAsync({
+        householdId,
+        petId: effectivePetId,
+        label: t.label,
+        time: t.time,
+        foodType: t.foodType || null,
+        amount: t.amount || null,
+      });
+    }
+    setApplyingTemplate(false);
   };
 
   const handleAdd = (e: React.FormEvent) => {
@@ -126,6 +151,30 @@ export function FeedingManageModal({ householdId, onClose }: FeedingManageModalP
       {/* Add new schedule form */}
       <fieldset style={fieldsetStyle}>
         <legend style={legendStyle}>Add New Schedule</legend>
+
+        {/* Template banner — shown when pet selected and no schedules yet */}
+        {effectivePetId && !petHasSchedules && (
+          <div style={templateBanner}>
+            <span style={templateBannerText}>
+              Use {PET_SPECIES_LABELS[petSpecies] ?? petSpecies} template?
+            </span>
+            <div style={templatePreview}>
+              {templates.map((t, i) => (
+                <span key={i} style={templateChip}>
+                  {t.label} {t.time}{t.foodType ? ` \u00B7 ${t.foodType}` : ""}
+                </span>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={handleApplyTemplate}
+              disabled={applyingTemplate}
+              style={templateApplyBtn(applyingTemplate)}
+            >
+              {applyingTemplate ? "Applying..." : "Apply Template"}
+            </button>
+          </div>
+        )}
 
         {/* Suggestion chips */}
         <div style={chipRow}>
@@ -454,3 +503,48 @@ const errorText: React.CSSProperties = {
   fontSize: "0.825rem",
   marginTop: "0.5rem",
 };
+
+const templateBanner: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  padding: "0.75rem",
+  marginBottom: "0.75rem",
+  borderRadius: "0.5rem",
+  background: "rgba(99, 102, 241, 0.06)",
+  border: "1px solid rgba(99, 102, 241, 0.15)",
+};
+
+const templateBannerText: React.CSSProperties = {
+  fontWeight: 600,
+  fontSize: "0.85rem",
+  color: "var(--pf-primary)",
+};
+
+const templatePreview: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.35rem",
+};
+
+const templateChip: React.CSSProperties = {
+  padding: "0.2rem 0.5rem",
+  borderRadius: "999px",
+  fontSize: "0.7rem",
+  fontWeight: 500,
+  background: "rgba(99, 102, 241, 0.1)",
+  color: "var(--pf-text-muted)",
+};
+
+const templateApplyBtn = (loading: boolean): React.CSSProperties => ({
+  alignSelf: "flex-start",
+  padding: "0.35rem 0.9rem",
+  borderRadius: "0.5rem",
+  background: "linear-gradient(135deg, #6366F1 0%, #7C3AED 100%)",
+  color: "white",
+  fontWeight: 600,
+  fontSize: "0.8rem",
+  border: "none",
+  cursor: loading ? "not-allowed" : "pointer",
+  opacity: loading ? 0.7 : 1,
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -67,6 +67,42 @@ export const FEEDING_TIME_PRESETS: Record<string, string> = {
   Snack: "15:00",
 };
 
+// --- Feeding Schedule Templates by Species ---
+
+export interface FeedingTemplateEntry {
+  label: string;
+  time: string;
+  foodType: string;
+  amount: string;
+}
+
+export const FEEDING_SCHEDULE_TEMPLATES: Record<string, FeedingTemplateEntry[]> = {
+  dog: [
+    { label: "Breakfast", time: "07:30", foodType: "Kibble", amount: "1 cup" },
+    { label: "Dinner", time: "17:30", foodType: "Kibble", amount: "1 cup" },
+  ],
+  cat: [
+    { label: "Morning", time: "07:00", foodType: "Wet food", amount: "1/2 can" },
+    { label: "Evening", time: "18:00", foodType: "Wet food", amount: "1/2 can" },
+    { label: "Kibble top-up", time: "12:00", foodType: "Dry food", amount: "1/4 cup" },
+  ],
+  bird: [
+    { label: "Morning seed", time: "08:00", foodType: "Seed mix", amount: "2 tbsp" },
+    { label: "Afternoon fresh", time: "14:00", foodType: "Fresh fruits/veggies", amount: "1 tbsp" },
+  ],
+  fish: [
+    { label: "Morning feed", time: "08:00", foodType: "Flakes", amount: "Pinch" },
+    { label: "Evening feed", time: "18:00", foodType: "Flakes", amount: "Pinch" },
+  ],
+  reptile: [
+    { label: "Feeding", time: "10:00", foodType: "Live insects / greens", amount: "Species-appropriate" },
+  ],
+  other: [
+    { label: "Breakfast", time: "08:00", foodType: "", amount: "" },
+    { label: "Dinner", time: "18:00", foodType: "", amount: "" },
+  ],
+};
+
 // --- Calendar ---
 
 export const ACTIVITY_TYPE_ICONS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Adds `FEEDING_SCHEDULE_TEMPLATES` to `@petforce/core/constants` with species-keyed feeding presets for dog, cat, bird, fish, reptile, and other
- When a pet has no feeding schedules yet, the FeedingManageModal shows a template banner with pre-built schedules for that pet's species
- One-click "Apply Template" creates all recommended schedules using the existing `createSchedule` mutation — no API or schema changes needed

Closes #143

## Changes
- `packages/core/src/constants.ts` — new `FeedingTemplateEntry` interface and `FEEDING_SCHEDULE_TEMPLATES` record (follows existing `COMMON_VACCINES` pattern)
- `apps/web/src/components/feeding-manage-modal.tsx` — template banner UI with preview chips and apply button, shown only when pet is selected and has no existing schedules

## Test plan
- [ ] Open feeding modal with a new pet (no schedules) — template banner should appear showing species-appropriate defaults
- [ ] Click "Apply Template" — all template entries should be created as feeding schedules
- [ ] Verify banner disappears after templates are applied (pet now has schedules)
- [ ] Verify multi-pet households show correct templates when switching between pets of different species
- [ ] Verify manual "Add" form still works independently of templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)