### PR TITLE
feat: link pet photos to care activities (PET-66)

### DIFF
--- a/apps/api/src/routers/pet-photo.ts
+++ b/apps/api/src/routers/pet-photo.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { eq, desc } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { protectedProcedure, router, verifyMembership } from "../trpc.js";
-import { db, pets, petPhotos } from "@petforce/db";
+import { db, pets, petPhotos, activities } from "@petforce/db";
 import { updatePetPhotoSchema } from "@petforce/core";
 import { deletePetPhotoFile } from "../lib/supabase-storage.js";
 
@@ -67,5 +67,44 @@ export const petPhotoRouter = router({
 
       await db.delete(petPhotos).where(eq(petPhotos.id, input.id));
       return { success: true };
+    }),
+
+  listByActivity: protectedProcedure
+    .input(z.object({ activityId: z.uuid() }))
+    .query(async ({ ctx, input }) => {
+      const [activity] = await db
+        .select()
+        .from(activities)
+        .where(eq(activities.id, input.activityId));
+      if (!activity) return [];
+
+      await verifyMembership(activity.householdId, ctx.userId);
+
+      return db
+        .select()
+        .from(petPhotos)
+        .where(eq(petPhotos.activityId, input.activityId))
+        .orderBy(desc(petPhotos.createdAt));
+    }),
+
+  linkToActivity: protectedProcedure
+    .input(z.object({ photoId: z.uuid(), activityId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const [photo] = await db
+        .select()
+        .from(petPhotos)
+        .where(eq(petPhotos.id, input.photoId));
+      if (!photo) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Photo not found" });
+      }
+
+      await verifyMembership(photo.householdId, ctx.userId);
+
+      const [updated] = await db
+        .update(petPhotos)
+        .set({ activityId: input.activityId })
+        .where(eq(petPhotos.id, input.photoId))
+        .returning();
+      return updated;
     }),
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -91,6 +91,7 @@ export const petPhotos = pgTable("pet_photos", {
   url: text("url").notNull(),
   caption: text("caption"),
   takenAt: timestamp("taken_at", { withTimezone: true }),
+  activityId: uuid("activity_id").references(() => activities.id, { onDelete: "set null" }),
   uploadedBy: uuid("uploaded_by")
     .notNull()
     .references(() => members.id, { onDelete: "cascade" }),
@@ -99,6 +100,7 @@ export const petPhotos = pgTable("pet_photos", {
   petIdx: index("pet_photos_pet_idx").on(table.petId),
   householdIdx: index("pet_photos_household_idx").on(table.householdId),
   uploadedByIdx: index("pet_photos_uploaded_by_idx").on(table.uploadedBy),
+  activityIdx: index("pet_photos_activity_idx").on(table.activityId),
 }));
 
 // --- Activities ---


### PR DESCRIPTION
## Summary
- Adds optional `activityId` FK column to `pet_photos` table, allowing photos to be attached to specific care log entries
- Adds `petPhoto.listByActivity` query to fetch photos linked to a specific activity
- Adds `petPhoto.linkToActivity` mutation to link an existing photo to a care event
- Fully backward-compatible: existing photos continue to work with `activityId` defaulting to null

## Changes
- `packages/db/src/schema.ts` — adds `activityId` column + index to `petPhotos` table
- `apps/api/src/routers/pet-photo.ts` — adds `listByActivity` and `linkToActivity` procedures

## Breaking changes
- **Migration required**: adds `activity_id` column and index to `pet_photos` table
- Run `pnpm --filter=@petforce/db db:generate` then review the generated SQL before applying

## Test plan
- [ ] Verify existing photo uploads still work (activityId is optional/nullable)
- [ ] Call `petPhoto.linkToActivity` to link a photo to an activity
- [ ] Call `petPhoto.listByActivity` to retrieve photos for a specific activity
- [ ] Verify deleting an activity sets `activityId` to null on linked photos (not cascade delete)
- [ ] Run migration in staging before production

🤖 Generated with [Claude Code](https://claude.com/claude-code)